### PR TITLE
Publish Allure reports in CI, add API controller tests, fix WPF/Blazor CI builds

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -68,9 +68,14 @@ jobs:
           -p:Version=${{ steps.ver.outputs.VERSION }}
 
       - name: Test
+        # VaultGuard.Web.Tests is never built by the "Build" step above (nothing here references it,
+        # since it's the Tests project that references VaultGuard.Web, not the other way round), so
+        # --no-build has nothing to run against - let dotnet test restore/build it itself. Also target
+        # the .csproj explicitly rather than the bare directory: on the .NET 10 SDK, --no-build against
+        # a directory path resolves to "The argument <dll> is invalid" instead of running the tests.
         run: |
           if [ -d "VaultGuard.Web.Tests" ]; then
-            dotnet test VaultGuard.Web.Tests --no-build --configuration Release
+            dotnet test VaultGuard.Web.Tests/VaultGuard.Web.Tests.csproj --configuration Release --logger "trx;LogFileName=web-tests.trx"
           else
             echo "No Web tests found, skipping"
           fi

--- a/.github/workflows/build-wpf.yml
+++ b/.github/workflows/build-wpf.yml
@@ -42,13 +42,15 @@ jobs:
         run: dotnet restore ${{ env.PROJECT }}
 
       - name: Build
+        # Only -p:Version is set here - the SDK derives AssemblyVersion/FileVersion from it
+        # automatically (stripping any -suffix, e.g. "-dev"), since those two MSBuild properties
+        # feed [AssemblyVersion]/[AssemblyFileVersion] attributes which require a purely numeric
+        # major[.minor[.build[.revision]]] value and would fail to compile (CS7034) otherwise.
         run: >
           dotnet build ${{ env.PROJECT }}
           --configuration Release
           --no-restore
           -p:Version=${{ steps.ver.outputs.VERSION }}
-          -p:AssemblyVersion=${{ steps.ver.outputs.VERSION }}
-          -p:FileVersion=${{ steps.ver.outputs.VERSION }}
 
       - name: Publish (self-contained win-x64)
         run: >

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,48 +14,53 @@ on:
       - '**.csproj'
       - '.github/workflows/run-tests.yml'
 
+permissions:
+  contents: write
+  checks: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Run Unit Tests
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '9.0.x'
-    
+
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '10.0.x'
-    
+
     - name: Restore dependencies
       run: dotnet restore
-    
+
     - name: Build test projects
       run: |
         dotnet build VaultGuard.App.Tests/VaultGuard.App.Tests.csproj --no-restore --configuration Release
         dotnet build VaultGuard.Web.Tests/VaultGuard.Web.Tests.csproj --no-restore --configuration Release
         dotnet build VaultGuard.WinUi.Tests/VaultGuard.WinUi.Tests.csproj --no-restore --configuration Release
-    
+
     - name: Run App Tests
       run: dotnet test VaultGuard.App.Tests/VaultGuard.App.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=app-tests.trx"
-    
+
     - name: Run Web Tests
       run: dotnet test VaultGuard.Web.Tests/VaultGuard.Web.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=web-tests.trx"
-    
+
     - name: Run WinUI Tests
       run: dotnet test VaultGuard.WinUi.Tests/VaultGuard.WinUi.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=winui-tests.trx"
-    
+
     - name: Run Backend Tests
+      if: always()
       run: |
         if [ -d "VaultGuard.BackEnd.Tests" ]; then
           dotnet test VaultGuard.BackEnd.Tests/VaultGuard.BackEnd.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=backend-tests.trx"
         fi
-    
+
     - name: Publish Test Results
       uses: dorny/test-reporter@v1
       if: always()
@@ -64,3 +69,45 @@ jobs:
         path: '**/*.trx'
         reporter: dotnet-trx
         fail-on-error: true
+
+    - name: Collect Allure results
+      if: always()
+      run: |
+        mkdir -p allure-results
+        find . -type d -name allure-results -not -path './allure-results' -exec sh -c 'cp -f "$1"/*.json allure-results/ 2>/dev/null || true' _ {} \;
+        echo "Collected $(find allure-results -type f | wc -l) Allure result files"
+
+    - name: Get Allure history
+      uses: actions/checkout@v4
+      if: always()
+      continue-on-error: true
+      with:
+        ref: gh-pages
+        path: gh-pages
+
+    - name: Build Allure report
+      uses: simple-elf/allure-report-action@master
+      if: always()
+      id: allure-report
+      with:
+        allure_results: allure-results
+        allure_history: allure-history
+        allure_report: allure-report
+        keep_reports: 20
+        gh_pages: gh-pages
+
+    - name: Publish Allure report to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: always() && github.event_name == 'push'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: allure-history
+
+    - name: Upload Allure report artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: allure-report
+        path: allure-history
+        retention-days: 20

--- a/VaultGuard.BackEnd.Tests/Controllers/ApiKeysControllerTests.cs
+++ b/VaultGuard.BackEnd.Tests/Controllers/ApiKeysControllerTests.cs
@@ -1,0 +1,269 @@
+using System.Security.Claims;
+using Allure.NUnit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using VaultGuard.API.Controllers;
+using VaultGuard.Crypto.Interfaces;
+using VaultGuard.Models;
+using VaultGuard.Services.Interfaces;
+
+namespace VaultGuard.BackEnd.Tests.Controllers;
+
+/// <summary>
+/// Tests for <see cref="ApiKeysController"/> - the "Generate API Key" / X-API-Key endpoints.
+/// Covers the auth-key issue flow (email + master password -> real, usable API key), the
+/// authenticated key CRUD (list/create/revoke), and that every authenticated action rejects
+/// callers with no NameIdentifier claim.
+/// </summary>
+[TestFixture]
+[AllureNUnit]
+public class ApiKeysControllerTests
+{
+    private Mock<IApiKeyService> _mockApiKeyService = null!;
+    private Mock<UserManager<ApplicationUser>> _mockUserManager = null!;
+    private Mock<IPasswordCryptoService> _mockCryptoService = null!;
+    private Mock<ILogger<ApiKeysController>> _mockLogger = null!;
+    private ApiKeysController _controller = null!;
+
+    private const string UserId = "user-1";
+    private const string Email = "user@example.com";
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockApiKeyService = new Mock<IApiKeyService>();
+        var store = new Mock<IUserStore<ApplicationUser>>();
+        _mockUserManager = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
+        _mockCryptoService = new Mock<IPasswordCryptoService>();
+        _mockLogger = new Mock<ILogger<ApiKeysController>>();
+
+        _controller = new ApiKeysController(
+            _mockApiKeyService.Object,
+            _mockUserManager.Object,
+            _mockCryptoService.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetAuthenticatedUser(string userId)
+    {
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, userId) }, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+    }
+
+    private void SetAnonymousUser()
+    {
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) }
+        };
+    }
+
+    private static ApplicationUser MakeUser(string userId = UserId, string email = Email) => new()
+    {
+        Id = userId,
+        UserName = email,
+        Email = email,
+        UserSalt = Convert.ToBase64String(new byte[16]),
+        MasterPasswordHash = "hashed",
+        MasterPasswordIterations = 600000
+    };
+
+    // ----- IssueApiKey -----
+
+    [Test]
+    public async Task IssueApiKey_MissingEmailOrPassword_ReturnsBadRequest()
+    {
+        var result = await _controller.IssueApiKey(new IssueApiKeyRequest { Email = "", MasterPassword = "" });
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public async Task IssueApiKey_UnknownEmail_ReturnsUnauthorized()
+    {
+        _mockUserManager.Setup(x => x.FindByEmailAsync(Email)).ReturnsAsync((ApplicationUser?)null);
+
+        var result = await _controller.IssueApiKey(new IssueApiKeyRequest { Email = Email, MasterPassword = "pw" });
+
+        Assert.That(result.Result, Is.InstanceOf<UnauthorizedObjectResult>());
+        _mockApiKeyService.Verify(x => x.CreateApiKeyAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task IssueApiKey_WrongMasterPassword_ReturnsUnauthorized()
+    {
+        var user = MakeUser();
+        _mockUserManager.Setup(x => x.FindByEmailAsync(Email)).ReturnsAsync(user);
+        _mockCryptoService.Setup(x => x.VerifyMasterPassword(
+                "wrong-password", user.MasterPasswordHash!, It.IsAny<byte[]>(), user.MasterPasswordIterations))
+            .Returns(false);
+
+        var result = await _controller.IssueApiKey(new IssueApiKeyRequest { Email = Email, MasterPassword = "wrong-password" });
+
+        Assert.That(result.Result, Is.InstanceOf<UnauthorizedObjectResult>());
+        _mockApiKeyService.Verify(x => x.CreateApiKeyAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task IssueApiKey_ValidCredentials_ReturnsOkWithPlaintextKeyOnce()
+    {
+        var user = MakeUser();
+        _mockUserManager.Setup(x => x.FindByEmailAsync(Email)).ReturnsAsync(user);
+        _mockCryptoService.Setup(x => x.VerifyMasterPassword(
+                "correct-password", user.MasterPasswordHash!, It.IsAny<byte[]>(), user.MasterPasswordIterations))
+            .Returns(true);
+
+        var issuedKey = new ApiKey { Id = Guid.NewGuid(), Name = "My key", KeyHash = "plaintext-key-value", UserId = user.Id };
+        _mockApiKeyService.Setup(x => x.CreateApiKeyAsync("My key", user.Id)).ReturnsAsync(issuedKey);
+
+        var result = await _controller.IssueApiKey(new IssueApiKeyRequest { Email = Email, MasterPassword = "correct-password", Name = "My key" });
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        var response = (ApiKeyResponse)((OkObjectResult)result.Result!).Value!;
+        Assert.That(response.KeyValue, Is.EqualTo("plaintext-key-value"));
+        Assert.That(response.Id, Is.EqualTo(issuedKey.Id));
+    }
+
+    [Test]
+    public async Task IssueApiKey_NoNameProvided_GeneratesDefaultName()
+    {
+        var user = MakeUser();
+        _mockUserManager.Setup(x => x.FindByEmailAsync(Email)).ReturnsAsync(user);
+        _mockCryptoService.Setup(x => x.VerifyMasterPassword(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<int>()))
+            .Returns(true);
+        _mockApiKeyService.Setup(x => x.CreateApiKeyAsync(It.IsAny<string>(), user.Id))
+            .ReturnsAsync((string name, string uid) => new ApiKey { Id = Guid.NewGuid(), Name = name, KeyHash = "key", UserId = uid });
+
+        var result = await _controller.IssueApiKey(new IssueApiKeyRequest { Email = Email, MasterPassword = "pw" });
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        var response = (ApiKeyResponse)((OkObjectResult)result.Result!).Value!;
+        Assert.That(response.Name, Does.StartWith("Test connection"));
+    }
+
+    // ----- GetUserApiKeys -----
+
+    [Test]
+    public async Task GetUserApiKeys_NoUserIdClaim_ReturnsUnauthorized()
+    {
+        SetAnonymousUser();
+
+        var result = await _controller.GetUserApiKeys();
+
+        Assert.That(result.Result, Is.InstanceOf<UnauthorizedResult>());
+    }
+
+    [Test]
+    public async Task GetUserApiKeys_ReturnsKeysWithHashHidden()
+    {
+        SetAuthenticatedUser(UserId);
+        var keys = new List<ApiKey>
+        {
+            new() { Id = Guid.NewGuid(), Name = "key-1", KeyHash = "real-hash-1", UserId = UserId },
+            new() { Id = Guid.NewGuid(), Name = "key-2", KeyHash = "real-hash-2", UserId = UserId }
+        };
+        _mockApiKeyService.Setup(x => x.GetUserApiKeysAsync(UserId)).ReturnsAsync(keys);
+
+        var result = await _controller.GetUserApiKeys();
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        var returned = (List<ApiKey>)((OkObjectResult)result.Result!).Value!;
+        Assert.That(returned, Has.Count.EqualTo(2));
+        Assert.That(returned.All(k => k.KeyHash == "***"), Is.True, "The key hash must never be exposed via the list endpoint.");
+    }
+
+    // ----- CreateApiKey -----
+
+    [Test]
+    public async Task CreateApiKey_NoUserIdClaim_ReturnsUnauthorized()
+    {
+        SetAnonymousUser();
+
+        var result = await _controller.CreateApiKey(new CreateApiKeyRequest { Name = "My key" });
+
+        Assert.That(result.Result, Is.InstanceOf<UnauthorizedResult>());
+    }
+
+    [Test]
+    public async Task CreateApiKey_EmptyName_ReturnsBadRequest()
+    {
+        SetAuthenticatedUser(UserId);
+
+        var result = await _controller.CreateApiKey(new CreateApiKeyRequest { Name = "" });
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockApiKeyService.Verify(x => x.CreateApiKeyAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreateApiKey_Valid_ReturnsOkWithKey()
+    {
+        SetAuthenticatedUser(UserId);
+        var created = new ApiKey { Id = Guid.NewGuid(), Name = "My key", KeyHash = "plaintext", UserId = UserId };
+        _mockApiKeyService.Setup(x => x.CreateApiKeyAsync("My key", UserId)).ReturnsAsync(created);
+
+        var result = await _controller.CreateApiKey(new CreateApiKeyRequest { Name = "My key" });
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        var response = (ApiKeyResponse)((OkObjectResult)result.Result!).Value!;
+        Assert.That(response.Id, Is.EqualTo(created.Id));
+        Assert.That(response.KeyValue, Is.EqualTo("plaintext"));
+    }
+
+    // ----- DeleteApiKey -----
+
+    [Test]
+    public async Task DeleteApiKey_NoUserIdClaim_ReturnsUnauthorized()
+    {
+        SetAnonymousUser();
+
+        var result = await _controller.DeleteApiKey(Guid.NewGuid());
+
+        Assert.That(result, Is.InstanceOf<UnauthorizedResult>());
+    }
+
+    [Test]
+    public async Task DeleteApiKey_ServiceReturnsTrue_ReturnsOk()
+    {
+        SetAuthenticatedUser(UserId);
+        var keyId = Guid.NewGuid();
+        _mockApiKeyService.Setup(x => x.DeleteApiKeyAsync(keyId, UserId)).ReturnsAsync(true);
+
+        var result = await _controller.DeleteApiKey(keyId);
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+    }
+
+    [Test]
+    public async Task DeleteApiKey_ServiceReturnsFalse_ReturnsNotFound()
+    {
+        SetAuthenticatedUser(UserId);
+        var keyId = Guid.NewGuid();
+        _mockApiKeyService.Setup(x => x.DeleteApiKeyAsync(keyId, UserId)).ReturnsAsync(false);
+
+        var result = await _controller.DeleteApiKey(keyId);
+
+        Assert.That(result, Is.InstanceOf<NotFoundResult>());
+    }
+
+    [Test]
+    public async Task DeleteApiKey_ScopesToCallingUser_NotArbitraryUserId()
+    {
+        SetAuthenticatedUser(UserId);
+        var keyId = Guid.NewGuid();
+        _mockApiKeyService.Setup(x => x.DeleteApiKeyAsync(keyId, UserId)).ReturnsAsync(true);
+
+        await _controller.DeleteApiKey(keyId);
+
+        _mockApiKeyService.Verify(x => x.DeleteApiKeyAsync(keyId, UserId), Times.Once);
+        _mockApiKeyService.Verify(x => x.DeleteApiKeyAsync(keyId, It.Is<string>(s => s != UserId)), Times.Never);
+    }
+}

--- a/VaultGuard.BackEnd.Tests/Controllers/PasswordItemsControllerTests.cs
+++ b/VaultGuard.BackEnd.Tests/Controllers/PasswordItemsControllerTests.cs
@@ -1,24 +1,328 @@
+using System.Security.Claims;
 using Allure.NUnit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using VaultGuard.API.Controllers;
+using VaultGuard.Crypto.Interfaces;
+using VaultGuard.Models;
+using VaultGuard.Models.DTOs;
+using VaultGuard.Services.Interfaces;
 
 namespace VaultGuard.BackEnd.Tests.Controllers;
 
+/// <summary>
+/// Tests for <see cref="PasswordItemsController"/> - the CRUD surface for stored password items
+/// (get/create/update/delete), across a couple of the different <see cref="ItemType"/> values
+/// (Login and CryptoWallet) to make sure the type field round-trips regardless of which item kind
+/// is being stored. Also covers the permission checks that gate every action and the IDOR guard
+/// (missing item vs. someone else's item both return 404, never 403, so an id can't be enumerated).
+/// </summary>
 [TestFixture]
 [AllureNUnit]
 public class PasswordItemsControllerTests
 {
-    // Simplified controller tests for PasswordItems
-    // Full integration tests would require the actual API service interfaces
-    // to be properly defined and implemented
-    
-    [Test]
-    public void PasswordItemsController_CanBeInstantiated()
+    private Mock<IPasswordItemApiService> _mockItemService = null!;
+    private Mock<IPasswordEncryptionService> _mockEncryptionService = null!;
+    private Mock<IVaultSessionService> _mockVaultSessionService = null!;
+    private Mock<IPasswordCryptoService> _mockCryptoService = null!;
+    private Mock<IPermissionService> _mockPermissionService = null!;
+    private Mock<UserManager<ApplicationUser>> _mockUserManager = null!;
+    private Mock<ILogger<PasswordItemsController>> _mockLogger = null!;
+    private PasswordItemsController _controller = null!;
+
+    private const string UserId = "user-1";
+    private const string OtherUserId = "user-2";
+
+    [SetUp]
+    public void Setup()
     {
-        // This is a placeholder test to ensure the test project structure works
-        // Real controller tests would need actual service interfaces to be tested
-        Assert.That(true, Is.True);
+        _mockItemService = new Mock<IPasswordItemApiService>();
+        _mockEncryptionService = new Mock<IPasswordEncryptionService>();
+        _mockVaultSessionService = new Mock<IVaultSessionService>();
+        _mockCryptoService = new Mock<IPasswordCryptoService>();
+        _mockPermissionService = new Mock<IPermissionService>();
+        var store = new Mock<IUserStore<ApplicationUser>>();
+        _mockUserManager = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
+        _mockLogger = new Mock<ILogger<PasswordItemsController>>();
+
+        _controller = new PasswordItemsController(
+            _mockItemService.Object,
+            _mockEncryptionService.Object,
+            _mockVaultSessionService.Object,
+            _mockCryptoService.Object,
+            _mockPermissionService.Object,
+            _mockUserManager.Object,
+            _mockLogger.Object);
+
+        // Default: authenticated as UserId, not a child, and allowed to do everything -
+        // individual tests override the specific permission they're exercising.
+        SetAuthenticatedUser(UserId);
+        _mockPermissionService.Setup(x => x.HasPermissionAsync(UserId, It.IsAny<string>())).ReturnsAsync(true);
+        _mockPermissionService.Setup(x => x.CanAccessResourceAsync(UserId, UserId, It.IsAny<string>())).ReturnsAsync(true);
+        _mockPermissionService.Setup(x => x.IsInRoleAsync(UserId, ApplicationRoles.Child)).ReturnsAsync(false);
+    }
+
+    private void SetAuthenticatedUser(string userId)
+    {
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, userId) }, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+    }
+
+    private static PasswordItemDto MakeItem(int id, string userId = UserId, ItemType type = ItemType.Login) => new()
+    {
+        Id = id,
+        Title = "Test item",
+        Type = type,
+        UserId = userId
+    };
+
+    // ----- GetAll -----
+
+    [Test]
+    public async Task GetAll_WithoutViewPermission_ReturnsForbid()
+    {
+        _mockPermissionService.Setup(x => x.HasPermissionAsync(UserId, Permissions.Passwords.View)).ReturnsAsync(false);
+
+        var result = await _controller.GetAll();
+
+        Assert.That(result.Result, Is.InstanceOf<ForbidResult>());
+    }
+
+    [Test]
+    public async Task GetAll_WithPermission_ReturnsOkWithItems()
+    {
+        var items = new List<PasswordItemDto> { MakeItem(1), MakeItem(2, type: ItemType.CryptoWallet) };
+        _mockItemService.Setup(x => x.GetAllAsync()).ReturnsAsync(items);
+
+        var result = await _controller.GetAll();
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        var returned = (IEnumerable<PasswordItemDto>)((OkObjectResult)result.Result!).Value!;
+        Assert.That(returned, Is.EqualTo(items));
+    }
+
+    [Test]
+    public async Task GetAll_ChildWithoutOperationPermission_ReturnsForbid()
+    {
+        _mockPermissionService.Setup(x => x.IsInRoleAsync(UserId, ApplicationRoles.Child)).ReturnsAsync(true);
+        _mockPermissionService.Setup(x => x.ChildCanPerformPasswordOperationAsync(UserId, "view")).ReturnsAsync(false);
+
+        var result = await _controller.GetAll();
+
+        Assert.That(result.Result, Is.InstanceOf<ForbidResult>());
+        _mockItemService.Verify(x => x.GetAllAsync(), Times.Never);
+    }
+
+    // ----- GetById -----
+
+    [Test]
+    public async Task GetById_ItemDoesNotExist_ReturnsNotFound()
+    {
+        _mockItemService.Setup(x => x.GetByIdAsync(42)).ReturnsAsync((PasswordItemDto?)null);
+
+        var result = await _controller.GetById(42);
+
+        Assert.That(result.Result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task GetById_ItemBelongsToAnotherUser_ReturnsNotFound_NotForbidden()
+    {
+        var item = MakeItem(1, userId: OtherUserId);
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(item);
+        _mockPermissionService.Setup(x => x.CanAccessResourceAsync(UserId, OtherUserId, Permissions.Passwords.View)).ReturnsAsync(false);
+
+        var result = await _controller.GetById(1);
+
+        // 404, not 403 - so a caller can't tell "not mine" apart from "doesn't exist" (IDOR guard).
+        Assert.That(result.Result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task GetById_OwnedItem_ReturnsOk()
+    {
+        var item = MakeItem(1);
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(item);
+
+        var result = await _controller.GetById(1);
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(((OkObjectResult)result.Result!).Value, Is.EqualTo(item));
+    }
+
+    // ----- Create -----
+
+    [Test]
+    public async Task Create_InvalidModel_ReturnsBadRequest()
+    {
+        _controller.ModelState.AddModelError("Title", "Title is required");
+
+        var result = await _controller.Create(new CreatePasswordItemDto());
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockItemService.Verify(x => x.CreateAsync(It.IsAny<CreatePasswordItemDto>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Create_WithoutCreatePermission_ReturnsForbid()
+    {
+        _mockPermissionService.Setup(x => x.HasPermissionAsync(UserId, Permissions.Passwords.Create)).ReturnsAsync(false);
+
+        var result = await _controller.Create(new CreatePasswordItemDto { Title = "New login", Type = ItemType.Login });
+
+        Assert.That(result.Result, Is.InstanceOf<ForbidResult>());
+    }
+
+    [Test]
+    public async Task Create_ChildRestrictedFromCreating_ReturnsForbid()
+    {
+        _mockPermissionService.Setup(x => x.IsInRoleAsync(UserId, ApplicationRoles.Child)).ReturnsAsync(true);
+        _mockPermissionService.Setup(x => x.ChildCanPerformPasswordOperationAsync(UserId, "create")).ReturnsAsync(false);
+
+        var result = await _controller.Create(new CreatePasswordItemDto { Title = "New login", Type = ItemType.Login });
+
+        Assert.That(result.Result, Is.InstanceOf<ForbidResult>());
+        _mockItemService.Verify(x => x.CreateAsync(It.IsAny<CreatePasswordItemDto>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Create_LoginItem_ReturnsCreatedAtGetById()
+    {
+        var createDto = new CreatePasswordItemDto { Title = "My login", Type = ItemType.Login };
+        var created = MakeItem(10, type: ItemType.Login);
+        _mockItemService.Setup(x => x.CreateAsync(createDto, UserId)).ReturnsAsync(created);
+
+        var result = await _controller.Create(createDto);
+
+        Assert.That(result.Result, Is.InstanceOf<CreatedAtActionResult>());
+        var createdResult = (CreatedAtActionResult)result.Result!;
+        Assert.That(createdResult.ActionName, Is.EqualTo(nameof(PasswordItemsController.GetById)));
+        Assert.That(createdResult.RouteValues?["id"], Is.EqualTo(created.Id));
+        Assert.That(((PasswordItemDto)createdResult.Value!).Type, Is.EqualTo(ItemType.Login));
+    }
+
+    [Test]
+    public async Task Create_CryptoWalletItem_PreservesType()
+    {
+        var createDto = new CreatePasswordItemDto { Title = "My wallet", Type = ItemType.CryptoWallet };
+        var created = MakeItem(11, type: ItemType.CryptoWallet);
+        _mockItemService.Setup(x => x.CreateAsync(createDto, UserId)).ReturnsAsync(created);
+
+        var result = await _controller.Create(createDto);
+
+        Assert.That(result.Result, Is.InstanceOf<CreatedAtActionResult>());
+        var value = (PasswordItemDto)((CreatedAtActionResult)result.Result!).Value!;
+        Assert.That(value.Type, Is.EqualTo(ItemType.CryptoWallet));
+
+        _mockItemService.Verify(x => x.CreateAsync(
+            It.Is<CreatePasswordItemDto>(d => d.Type == ItemType.CryptoWallet), UserId), Times.Once);
+    }
+
+    // ----- Update -----
+
+    [Test]
+    public async Task Update_InvalidModel_ReturnsBadRequest()
+    {
+        _controller.ModelState.AddModelError("Title", "Title is required");
+
+        var result = await _controller.Update(1, new UpdatePasswordItemDto());
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public async Task Update_ItemDoesNotExist_ReturnsNotFound()
+    {
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync((PasswordItemDto?)null);
+
+        var result = await _controller.Update(1, new UpdatePasswordItemDto { Title = "Updated" });
+
+        Assert.That(result.Result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task Update_WithoutEditPermission_ReturnsForbid()
+    {
+        var existing = MakeItem(1, userId: OtherUserId);
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(existing);
+        _mockPermissionService.Setup(x => x.CanAccessResourceAsync(UserId, OtherUserId, Permissions.Passwords.Edit)).ReturnsAsync(false);
+
+        var result = await _controller.Update(1, new UpdatePasswordItemDto { Title = "Updated" });
+
+        Assert.That(result.Result, Is.InstanceOf<ForbidResult>());
+        _mockItemService.Verify(x => x.UpdateAsync(It.IsAny<int>(), It.IsAny<UpdatePasswordItemDto>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Update_Valid_ReturnsOkWithUpdatedItem()
+    {
+        var existing = MakeItem(1);
+        var updateDto = new UpdatePasswordItemDto { Title = "Updated title" };
+        var updated = MakeItem(1);
+        updated.Title = "Updated title";
+
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(existing);
+        _mockItemService.Setup(x => x.UpdateAsync(1, updateDto)).ReturnsAsync(updated);
+
+        var result = await _controller.Update(1, updateDto);
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(((PasswordItemDto)((OkObjectResult)result.Result!).Value!).Title, Is.EqualTo("Updated title"));
+    }
+
+    // ----- Delete -----
+
+    [Test]
+    public async Task Delete_ItemDoesNotExist_ReturnsNotFound()
+    {
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync((PasswordItemDto?)null);
+
+        var result = await _controller.Delete(1);
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task Delete_ItemBelongsToAnotherUser_ReturnsNotFound()
+    {
+        var item = MakeItem(1, userId: OtherUserId);
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(item);
+        _mockPermissionService.Setup(x => x.CanAccessResourceAsync(UserId, OtherUserId, Permissions.Passwords.Delete)).ReturnsAsync(false);
+
+        var result = await _controller.Delete(1);
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+        _mockItemService.Verify(x => x.DeleteAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Delete_Valid_ReturnsNoContent()
+    {
+        var item = MakeItem(1);
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(item);
+        _mockItemService.Setup(x => x.DeleteAsync(1)).ReturnsAsync(true);
+
+        var result = await _controller.Delete(1);
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task Delete_ServiceReturnsFalse_ReturnsNotFound()
+    {
+        var item = MakeItem(1);
+        _mockItemService.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(item);
+        _mockItemService.Setup(x => x.DeleteAsync(1)).ReturnsAsync(false);
+
+        var result = await _controller.Delete(1);
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
     }
 }

--- a/VaultGuard.BackEnd.Tests/Controllers/UserProfileControllerTests.cs
+++ b/VaultGuard.BackEnd.Tests/Controllers/UserProfileControllerTests.cs
@@ -1,0 +1,286 @@
+using Allure.NUnit;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using VaultGuard.API.Controllers;
+using VaultGuard.Models.DTOs.Auth;
+using VaultGuard.Services.Interfaces;
+
+namespace VaultGuard.BackEnd.Tests.Controllers;
+
+/// <summary>
+/// Tests for <see cref="UserProfileController"/> - the admin-only user settings CRUD (list/get/create/
+/// update/deactivate/reactivate/delete) plus the master-password change endpoint. All controller logic
+/// here just delegates to <see cref="IUserProfileService"/> and translates the result to the right HTTP
+/// status, so the tests exercise exactly that mapping.
+/// </summary>
+[TestFixture]
+[AllureNUnit]
+public class UserProfileControllerTests
+{
+    private Mock<IUserProfileService> _mockUserProfileService = null!;
+    private Mock<ILogger<UserProfileController>> _mockLogger = null!;
+    private UserProfileController _controller = null!;
+
+    private const string UserId = "user-1";
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockUserProfileService = new Mock<IUserProfileService>();
+        _mockLogger = new Mock<ILogger<UserProfileController>>();
+        _controller = new UserProfileController(_mockUserProfileService.Object, _mockLogger.Object);
+    }
+
+    private static UserDto MakeUserDto(string id = UserId) => new()
+    {
+        Id = id,
+        Email = "user@example.com",
+        FirstName = "Ada",
+        LastName = "Lovelace",
+        CreatedAt = DateTime.UtcNow.AddDays(-30),
+        IsActive = true
+    };
+
+    // ----- GetAllUsers -----
+
+    [Test]
+    public async Task GetAllUsers_ReturnsOkWithUsers()
+    {
+        var users = new List<UserDto> { MakeUserDto("user-1"), MakeUserDto("user-2") };
+        _mockUserProfileService.Setup(x => x.GetAllUsersAsync()).ReturnsAsync(users);
+
+        var result = await _controller.GetAllUsers();
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(((OkObjectResult)result.Result!).Value, Is.EqualTo(users));
+    }
+
+    [Test]
+    public async Task GetAllUsers_WhenServiceThrows_ReturnsInternalServerError()
+    {
+        _mockUserProfileService.Setup(x => x.GetAllUsersAsync()).ThrowsAsync(new Exception("db error"));
+
+        var result = await _controller.GetAllUsers();
+
+        Assert.That(result.Result, Is.InstanceOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(500));
+    }
+
+    // ----- GetUserById -----
+
+    [Test]
+    public async Task GetUserById_UnknownId_ReturnsNotFound()
+    {
+        _mockUserProfileService.Setup(x => x.GetUserByIdAsync("missing")).ReturnsAsync((UserProfileDetailsDto?)null);
+
+        var result = await _controller.GetUserById("missing");
+
+        Assert.That(result.Result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task GetUserById_KnownId_ReturnsOkWithDetails()
+    {
+        var details = new UserProfileDetailsDto { Id = UserId, Email = "user@example.com", TwoFactorEnabled = true };
+        _mockUserProfileService.Setup(x => x.GetUserByIdAsync(UserId)).ReturnsAsync(details);
+
+        var result = await _controller.GetUserById(UserId);
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(((OkObjectResult)result.Result!).Value, Is.EqualTo(details));
+    }
+
+    // ----- CreateUser -----
+
+    [Test]
+    public async Task CreateUser_InvalidModel_ReturnsBadRequest()
+    {
+        _controller.ModelState.AddModelError("Email", "Email is required");
+
+        var result = await _controller.CreateUser(new CreateUserProfileDto());
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockUserProfileService.Verify(x => x.CreateUserAsync(It.IsAny<CreateUserProfileDto>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreateUser_ServiceFails_ReturnsBadRequestWithErrors()
+    {
+        var createDto = new CreateUserProfileDto { Email = "new@example.com", Password = "password123", ConfirmPassword = "password123", FirstName = "A", LastName = "B" };
+        var failedResult = IdentityResult.Failed(new IdentityError { Description = "Email already taken" });
+        _mockUserProfileService.Setup(x => x.CreateUserAsync(createDto)).ReturnsAsync((failedResult, null, "Email already taken"));
+
+        var result = await _controller.CreateUser(createDto);
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public async Task CreateUser_Valid_ReturnsCreatedAtGetUserById()
+    {
+        var createDto = new CreateUserProfileDto { Email = "new@example.com", Password = "password123", ConfirmPassword = "password123", FirstName = "A", LastName = "B" };
+        var newUser = new VaultGuard.Models.ApplicationUser { Id = "new-user-id", Email = createDto.Email, FirstName = "A", LastName = "B" };
+        _mockUserProfileService.Setup(x => x.CreateUserAsync(createDto)).ReturnsAsync((IdentityResult.Success, newUser, (string?)null));
+
+        var result = await _controller.CreateUser(createDto);
+
+        Assert.That(result.Result, Is.InstanceOf<CreatedAtActionResult>());
+        var createdResult = (CreatedAtActionResult)result.Result!;
+        Assert.That(createdResult.ActionName, Is.EqualTo(nameof(UserProfileController.GetUserById)));
+        Assert.That(createdResult.RouteValues?["id"], Is.EqualTo(newUser.Id));
+    }
+
+    // ----- UpdateUserProfile -----
+
+    [Test]
+    public async Task UpdateUserProfile_IdMismatch_ReturnsBadRequest()
+    {
+        var updateDto = new UpdateUserProfileDto { Id = "different-id" };
+
+        var result = await _controller.UpdateUserProfile(UserId, updateDto);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockUserProfileService.Verify(x => x.UpdateUserProfileAsync(It.IsAny<UpdateUserProfileDto>()), Times.Never);
+    }
+
+    [Test]
+    public async Task UpdateUserProfile_ServiceFails_ReturnsBadRequest()
+    {
+        var updateDto = new UpdateUserProfileDto { Id = UserId, Email = "bad" };
+        _mockUserProfileService.Setup(x => x.UpdateUserProfileAsync(updateDto)).ReturnsAsync((false, "Invalid email"));
+
+        var result = await _controller.UpdateUserProfile(UserId, updateDto);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public async Task UpdateUserProfile_Valid_ReturnsNoContent()
+    {
+        var updateDto = new UpdateUserProfileDto { Id = UserId, FirstName = "Updated" };
+        _mockUserProfileService.Setup(x => x.UpdateUserProfileAsync(updateDto)).ReturnsAsync((true, (string?)null));
+
+        var result = await _controller.UpdateUserProfile(UserId, updateDto);
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+    }
+
+    // ----- ChangeUserPassword -----
+
+    [Test]
+    public async Task ChangeUserPassword_IdMismatch_ReturnsBadRequest()
+    {
+        var changeDto = new ChangePasswordDto { Id = "different-id" };
+
+        var result = await _controller.ChangeUserPassword(UserId, changeDto);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockUserProfileService.Verify(x => x.ChangeMasterPasswordAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ChangeUserPassword_WrongCurrentPassword_ReturnsBadRequest()
+    {
+        var changeDto = new ChangePasswordDto
+        {
+            Id = UserId,
+            CurrentPassword = "wrong-old-password",
+            NewPassword = "new-password-123",
+            ConfirmNewPassword = "new-password-123"
+        };
+        _mockUserProfileService.Setup(x => x.ChangeMasterPasswordAsync(UserId, "wrong-old-password", "new-password-123", null))
+            .ReturnsAsync((false, "Current password is incorrect"));
+
+        var result = await _controller.ChangeUserPassword(UserId, changeDto);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(((BadRequestObjectResult)result).Value, Is.EqualTo("Current password is incorrect"));
+    }
+
+    [Test]
+    public async Task ChangeUserPassword_Valid_ReturnsNoContent()
+    {
+        var changeDto = new ChangePasswordDto
+        {
+            Id = UserId,
+            CurrentPassword = "old-password-123",
+            NewPassword = "new-password-123",
+            ConfirmNewPassword = "new-password-123"
+        };
+        _mockUserProfileService.Setup(x => x.ChangeMasterPasswordAsync(UserId, "old-password-123", "new-password-123", null))
+            .ReturnsAsync((true, (string?)null));
+
+        var result = await _controller.ChangeUserPassword(UserId, changeDto);
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+        _mockUserProfileService.Verify(x => x.ChangeMasterPasswordAsync(UserId, "old-password-123", "new-password-123", null), Times.Once);
+    }
+
+    // ----- Deactivate / Reactivate -----
+
+    [Test]
+    public async Task DeactivateUser_UnknownId_ReturnsNotFound()
+    {
+        _mockUserProfileService.Setup(x => x.DeactivateUserAsync("missing")).ReturnsAsync(false);
+
+        var result = await _controller.DeactivateUser("missing");
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task DeactivateUser_Valid_ReturnsNoContent()
+    {
+        _mockUserProfileService.Setup(x => x.DeactivateUserAsync(UserId)).ReturnsAsync(true);
+
+        var result = await _controller.DeactivateUser(UserId);
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task ReactivateUser_UnknownId_ReturnsNotFound()
+    {
+        _mockUserProfileService.Setup(x => x.ReactivateUserAsync("missing")).ReturnsAsync(false);
+
+        var result = await _controller.ReactivateUser("missing");
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task ReactivateUser_Valid_ReturnsNoContent()
+    {
+        _mockUserProfileService.Setup(x => x.ReactivateUserAsync(UserId)).ReturnsAsync(true);
+
+        var result = await _controller.ReactivateUser(UserId);
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+    }
+
+    // ----- DeleteUser -----
+
+    [Test]
+    public async Task DeleteUser_UnknownId_ReturnsNotFound()
+    {
+        _mockUserProfileService.Setup(x => x.DeleteUserAsync("missing")).ReturnsAsync(false);
+
+        var result = await _controller.DeleteUser("missing");
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task DeleteUser_Valid_ReturnsNoContent()
+    {
+        _mockUserProfileService.Setup(x => x.DeleteUserAsync(UserId)).ReturnsAsync(true);
+
+        var result = await _controller.DeleteUser(UserId);
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+    }
+}


### PR DESCRIPTION
## Summary
- **Allure in CI**: `run-tests.yml` now generates the Allure HTML report after tests, keeps trend history across runs via a `gh-pages` branch, publishes it there on `push` builds, and uploads it as a build artifact on every run (PRs included, where the Pages publish step is skipped since forked PRs can't push).
- **New unit tests** (mirroring the existing `CollectionsControllerTests` mocking pattern):
  - `ApiKeysControllerTests` — issuing a key from email + master password, wrong/unknown credentials, list (hash always hidden from the response), create, delete (scoped to the caller only).
  - `PasswordItemsControllerTests` — CRUD (get/create/update/delete), the IDOR guard (missing item vs. someone else's item both 404, never 403), and coverage across `ItemType.Login` and `ItemType.CryptoWallet`.
  - `UserProfileControllerTests` — settings CRUD (list/get/create/update/deactivate/reactivate/delete) plus the master-password change endpoint.
- **CI fixes** (both workflows were failing on every recent `devmain` build):
  - `build-wpf.yml`: dropped `-p:AssemblyVersion=` / `-p:FileVersion=` overrides set to a suffixed dev version string (e.g. `0.0.0-dev`), which isn't a valid value for those attributes and broke every non-tag build with `CS7034`. The SDK already derives them correctly from `-p:Version`.
  - `build-web.yml`: the Test step ran `dotnet test VaultGuard.Web.Tests --no-build`, but `VaultGuard.Web.Tests.csproj` is never built by the preceding Build step (the Tests project references `VaultGuard.Web`, not the other way round), and `--no-build` against a bare directory on the .NET 10 SDK produced `The argument ...dll is invalid`. Now targets the `.csproj` directly and lets `dotnet test` build it itself.

## Test plan
- [ ] Confirm `Build WPF (Windows)` goes green on this PR
- [ ] Confirm `Build Web (Blazor)` goes green on this PR
- [ ] Confirm the `Unit Tests` workflow picks up and passes the new controller tests
- [ ] After merge, enable GitHub Pages (Settings → Pages → branch: `gh-pages`) once the first `gh-pages` push lands, to view the Allure report


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8ZE1Fs5vjdqdRuKgPPhy1)_