### PR TITLE
Trigger a real Build Web (Blazor) run to verify the badge

### DIFF
--- a/VaultGuard.Web/Program.cs
+++ b/VaultGuard.Web/Program.cs
@@ -443,3 +443,4 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.Run();
+


### PR DESCRIPTION
## Summary
Whitespace-only change to `VaultGuard.Web/Program.cs`. `Build Web (Blazor)` is path-filtered and this repo's GitHub token doesn't have `actions:write` (manual `workflow_dispatch` via API returns 403), so there's been no way to get a real run against current `devmain` since the Blazor test-step fix in #452 - the badge has been showing a stale failure from before that fix. This PR exists purely to trigger the check so it can be confirmed green (or, if still broken, fixed) before merging.

## Test plan
- [ ] Confirm `Build Web (Blazor)` goes green on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8ZE1Fs5vjdqdRuKgPPhy1)_