### PR TITLE
Fix Build Docs Site: grant contents:write so gh-pages can be published

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/build-docs.yml'
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
After PR #456 merged, the `Build Docs Site` workflow ran on the resulting push to `devmain` but failed at the publish step:

```
remote: Permission to dotnetappdev/PasswordManagerApp.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

The workflow never declared `permissions: contents: write`, so its `GITHUB_TOKEN` only had default read access - `peaceiris/actions-gh-pages` couldn't push the `gh-pages` branch (which also didn't exist yet, so it was never created). This is why `gh-pages` doesn't show up in the branch list and Pages has nothing to serve.

`run-tests.yml` and `screenshots.yml` already declare this permission; `build-docs.yml` was missed.

## Fix
Added:
```yaml
permissions:
  contents: write
```

Once this merges, the resulting push to `devmain` will re-run `Build Docs Site` and should successfully create/publish `gh-pages` this time.

## Test plan
- [ ] Confirm `Build Docs Site` goes green on the merge push
- [ ] Confirm `gh-pages` branch now exists
- [ ] After that, enable GitHub Pages (Settings → Pages → branch: `gh-pages`) if not already on

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8ZE1Fs5vjdqdRuKgPPhy1)_