### PR TITLE
Deploy VaultGuard.Web to SmarterASP.NET + automated versioning/releases

### DIFF
--- a/.github/workflows/deploy-api-smarterasp.yml
+++ b/.github/workflows/deploy-api-smarterasp.yml
@@ -33,7 +33,7 @@ env:
   RUNTIME_ID: win-x64
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test-and-deploy:
@@ -44,12 +44,33 @@ jobs:
     name: Test & Deploy VaultGuard.API
 
     steps:
+      # Explicit ref + full history: pull_request's default checkout is a synthetic merge commit that
+      # doesn't exist in the branch's real history (bad tag target), and version-bumping below needs the
+      # full tag history, not the default shallow clone.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # Next version = latest api-vX.Y.Z tag with patch+1, or 1.0.0 if none exists yet.
+      - name: Compute next version
+        id: ver
+        shell: bash
+        run: |
+          latest=$(git tag -l 'api-v*' | sed 's/^api-v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)
+          if [ -z "$latest" ]; then
+            next="1.0.0"
+          else
+            IFS='.' read -r major minor patch <<< "$latest"
+            next="$major.$minor.$((patch + 1))"
+          fi
+          echo "Next version: $next"
+          echo "VERSION=$next" >> "$GITHUB_OUTPUT"
 
       - name: Restore backend tests
         run: dotnet restore ${{ env.TEST_PROJECT }}
@@ -77,6 +98,7 @@ jobs:
         run: >
           dotnet publish ${{ env.PROJECT }} --configuration Release --no-restore
           --self-contained true -r ${{ env.RUNTIME_ID }}
+          -p:Version=${{ steps.ver.outputs.VERSION }}
           --output ${{ env.PUBLISH_DIR }}
 
       # See ReadMe.md "Deploying the API to SmarterASP.NET" for where these come from in the
@@ -90,3 +112,31 @@ jobs:
           server-password: ${{ secrets.APIPASSWORD }}
           source-path: '${{ env.PUBLISH_DIR }}\'
           target-delete: 'true'
+
+      # Only reached if the deploy above succeeded: tag the deployed commit, branch off it, zip the
+      # publish output, and turn all of that into a GitHub Release - the whole tag/branch/release cycle
+      # runs here with no manual `git tag && git push` step needed.
+      - name: Tag release and create release branch
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          git tag "api-v${{ steps.ver.outputs.VERSION }}" "$sha"
+          git push origin "api-v${{ steps.ver.outputs.VERSION }}"
+          git branch "release/api-v${{ steps.ver.outputs.VERSION }}" "$sha"
+          git push origin "release/api-v${{ steps.ver.outputs.VERSION }}"
+
+      - name: Zip publish output
+        shell: pwsh
+        run: Compress-Archive -Path "${{ env.PUBLISH_DIR }}\*" -DestinationPath "VaultGuardAPI-${{ steps.ver.outputs.VERSION }}.zip"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: api-v${{ steps.ver.outputs.VERSION }}
+          name: VaultGuard API v${{ steps.ver.outputs.VERSION }}
+          generate_release_notes: true
+          files: VaultGuardAPI-${{ steps.ver.outputs.VERSION }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-web-smarterasp.yml
+++ b/.github/workflows/deploy-web-smarterasp.yml
@@ -36,7 +36,7 @@ env:
   RUNTIME_ID: win-x64
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test-and-deploy:
@@ -46,12 +46,33 @@ jobs:
     name: Test & Deploy VaultGuard.Web
 
     steps:
+      # Explicit ref + full history: pull_request's default checkout is a synthetic merge commit that
+      # doesn't exist in the branch's real history (bad tag target), and version-bumping below needs the
+      # full tag history, not the default shallow clone.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # Next version = latest web-vX.Y.Z tag with patch+1, or 1.0.0 if none exists yet.
+      - name: Compute next version
+        id: ver
+        shell: bash
+        run: |
+          latest=$(git tag -l 'web-v*' | sed 's/^web-v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)
+          if [ -z "$latest" ]; then
+            next="1.0.0"
+          else
+            IFS='.' read -r major minor patch <<< "$latest"
+            next="$major.$minor.$((patch + 1))"
+          fi
+          echo "Next version: $next"
+          echo "VERSION=$next" >> "$GITHUB_OUTPUT"
 
       - name: Restore web tests
         run: dotnet restore ${{ env.TEST_PROJECT }}
@@ -79,6 +100,7 @@ jobs:
         run: >
           dotnet publish ${{ env.PROJECT }} --configuration Release --no-restore
           --self-contained true -r ${{ env.RUNTIME_ID }}
+          -p:Version=${{ steps.ver.outputs.VERSION }}
           --output ${{ env.PUBLISH_DIR }}
 
       # See ReadMe.md "Deploying the Web app to SmarterASP.NET" for where these come from in the
@@ -97,3 +119,31 @@ jobs:
           server-password: ${{ secrets.BLAZORPASSWORD }}
           source-path: '${{ env.PUBLISH_DIR }}\'
           target-delete: 'true'
+
+      # Only reached if the deploy above succeeded: tag the deployed commit, branch off it, zip the
+      # publish output, and turn all of that into a GitHub Release - the whole tag/branch/release cycle
+      # runs here with no manual `git tag && git push` step needed.
+      - name: Tag release and create release branch
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          git tag "web-v${{ steps.ver.outputs.VERSION }}" "$sha"
+          git push origin "web-v${{ steps.ver.outputs.VERSION }}"
+          git branch "release/web-v${{ steps.ver.outputs.VERSION }}" "$sha"
+          git push origin "release/web-v${{ steps.ver.outputs.VERSION }}"
+
+      - name: Zip publish output
+        shell: pwsh
+        run: Compress-Archive -Path "${{ env.PUBLISH_DIR }}\*" -DestinationPath "VaultGuardWeb-${{ steps.ver.outputs.VERSION }}.zip"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: web-v${{ steps.ver.outputs.VERSION }}
+          name: VaultGuard Web v${{ steps.ver.outputs.VERSION }}
+          generate_release_notes: true
+          files: VaultGuardWeb-${{ steps.ver.outputs.VERSION }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-web-smarterasp.yml
+++ b/.github/workflows/deploy-web-smarterasp.yml
@@ -1,0 +1,99 @@
+name: Deploy Web to SmarterASP.NET
+
+# Deploys ONLY VaultGuard.Web (the Blazor Server web app) to SmarterASP.NET via Web Deploy, and only
+# when:
+#   1. A PR is opened/updated against devmain touching Web-relevant code, AND
+#   2. VaultGuard.Web.Tests pass.
+# The test step runs before publish/deploy in the same job, so a test failure stops the job there -
+# publish and deploy never run. Mirrors deploy-api-smarterasp.yml - see that file/ReadMe.md for the
+# reasoning behind self-contained publish and the OutOfProcess hosting model.
+on:
+  pull_request:
+    branches: [ devmain ]
+    paths:
+      - 'VaultGuard.Web/**'
+      - 'VaultGuard.Models/**'
+      - 'VaultGuard.Components.Shared/**'
+      - 'VaultGuard.DAL/**'
+      - 'VaultGuard.Services/**'
+      - 'VaultGuard.Crypto/**'
+      - 'VaultGuard.Imports/**'
+      - 'VaultGuard.DAL.SqlServer/**'
+      - 'VaultGuard.DAL.MySql/**'
+      - 'VaultGuard.DAL.Postgres/**'
+      - 'VaultGuard.DAL.SupaBase/**'
+      - 'VaultGuard.Web.Tests/**'
+      - '.github/workflows/deploy-web-smarterasp.yml'
+  workflow_dispatch: {}
+
+env:
+  PROJECT: VaultGuard.Web/VaultGuard.Web.csproj
+  TEST_PROJECT: VaultGuard.Web.Tests/VaultGuard.Web.Tests.csproj
+  PUBLISH_DIR: publish\web
+  DOTNET_VERSION: '10.0.x'
+  # Same reasoning as deploy-api-smarterasp.yml: SmarterASP.NET's IIS hosts are Windows x64, so a
+  # self-contained publish means the server doesn't need a matching .NET 10 runtime installed.
+  RUNTIME_ID: win-x64
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-deploy:
+    # jahbenjah/SmarterASP.NET-web-deploy shells out to msdeploy.exe at a hardcoded Windows path, so
+    # this only runs on Windows.
+    runs-on: windows-latest
+    name: Test & Deploy VaultGuard.Web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore web tests
+        run: dotnet restore ${{ env.TEST_PROJECT }}
+
+      - name: Build web tests
+        run: dotnet build ${{ env.TEST_PROJECT }} --no-restore --configuration Release
+
+      # Gate: everything below only runs if this succeeds.
+      - name: Run web unit tests
+        run: dotnet test ${{ env.TEST_PROJECT }} --no-build --configuration Release --logger "trx;LogFileName=web-tests.trx"
+
+      - name: Publish Test Results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Web Unit Test Results
+          path: '**/web-tests.trx'
+          reporter: dotnet-trx
+          fail-on-error: true
+
+      - name: Restore Web
+        run: dotnet restore ${{ env.PROJECT }} -r ${{ env.RUNTIME_ID }}
+
+      - name: Publish Web (self-contained)
+        run: >
+          dotnet publish ${{ env.PROJECT }} --configuration Release --no-restore
+          --self-contained true -r ${{ env.RUNTIME_ID }}
+          --output ${{ env.PUBLISH_DIR }}
+
+      # See ReadMe.md "Deploying the Web app to SmarterASP.NET" for where these come from in the
+      # SmarterASP.NET control panel's Web Deploy settings.
+      #
+      # NOTE: server-computer-name reuses APISERVER below - there's no separate BLAZORSERVER secret, and
+      # SmarterASP.NET accounts commonly use one Web Deploy server address for every site/subdomain under
+      # the same account, with only the site name/credentials differing per site. If the Blazor site is
+      # actually on a different server, add a dedicated secret and swap it in here.
+      - name: Deploy to SmarterASP.NET
+        uses: jahbenjah/SmarterASP.NET-web-deploy@1.0.0.alpha.8
+        with:
+          website-name: ${{ secrets.BLAZORSITENAME }}
+          server-computer-name: ${{ secrets.APISERVER }}
+          server-username: ${{ secrets.BLAZORUSERNAME }}
+          server-password: ${{ secrets.BLAZORPASSWORD }}
+          source-path: '${{ env.PUBLISH_DIR }}\'
+          target-delete: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Automated Release
+
+# Manual release path: push a tag like v1.2.3 and this builds + zips both VaultGuard.API and
+# VaultGuard.Web (self-contained, win-x64), creates a release/vX.Y.Z branch off that commit, and
+# publishes a GitHub Release with both zips attached.
+#
+# This is separate from the automatic per-deploy releases in deploy-api-smarterasp.yml /
+# deploy-web-smarterasp.yml (which tag as api-vX.Y.Z / web-vX.Y.Z on every successful SmarterASP.NET
+# deploy, no manual tagging needed) - use this one when you want to cut a single combined release by
+# hand. build-api.yml and build-web.yml also already build+zip+release their own project individually on
+# a v* tag push (without a release branch) - all three contribute files to the same GitHub Release for a
+# given tag rather than conflicting, but this does mean a v* tag triggers three workflow runs.
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  RUNTIME_ID: win-x64
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create Release Branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH_NAME="release/${{ github.ref_name }}"
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
+
+      - name: Extract version from tag
+        id: ver
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Publish API (self-contained)
+        run: >
+          dotnet publish VaultGuard.API/VaultGuard.API.csproj --configuration Release
+          --self-contained true -r ${{ env.RUNTIME_ID }}
+          -p:Version=${{ steps.ver.outputs.VERSION }}
+          --output publish/api
+
+      - name: Publish Web (self-contained)
+        run: >
+          dotnet publish VaultGuard.Web/VaultGuard.Web.csproj --configuration Release
+          --self-contained true -r ${{ env.RUNTIME_ID }}
+          -p:Version=${{ steps.ver.outputs.VERSION }}
+          --output publish/web
+
+      - name: Bundle Files
+        run: |
+          (cd publish/api && zip -r "$OLDPWD/VaultGuardAPI-${{ steps.ver.outputs.VERSION }}.zip" .)
+          (cd publish/web && zip -r "$OLDPWD/VaultGuardWeb-${{ steps.ver.outputs.VERSION }}.zip" .)
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            VaultGuardAPI-${{ steps.ver.outputs.VERSION }}.zip
+            VaultGuardWeb-${{ steps.ver.outputs.VERSION }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -228,6 +228,30 @@ SmarterASP.NET control panel's Web Deploy settings:
 > that isn't part of the published API output gets removed on each deploy - point it at a site/folder
 > dedicated to the API, not one shared with other content.
 
+## Deploying the Web app to SmarterASP.NET
+
+`.github/workflows/deploy-web-smarterasp.yml` mirrors the API workflow above for **only**
+`VaultGuard.Web` (the Blazor Server web app) - same action, same self-contained `win-x64` publish, same
+`AspNetCoreHostingModel=OutOfProcess` reasoning (already set in `VaultGuard.Web.csproj`).
+
+**When it runs:** on every pull request into `devmain` that touches Web-relevant code (`VaultGuard.Web`,
+`VaultGuard.Components.Shared`, or the web test project). `VaultGuard.Web.Tests` runs first in the same
+job - publish and deploy only happen if it passes.
+
+**Required GitHub repo secrets:**
+
+| Secret | Value |
+|---|---|
+| `BLAZORUSERNAME` | Web Deploy username |
+| `BLAZORPASSWORD` | Web Deploy password |
+| `BLAZORSITENAME` | Web Deploy site name |
+
+> **No separate server secret:** this workflow reuses `APISERVER` for `server-computer-name` - there's
+> no `BLAZORSERVER` secret, and SmarterASP.NET accounts commonly use one Web Deploy server address for
+> every site/subdomain under the account, with only the site name/credentials differing. If the Blazor
+> site is actually on a different server, add a dedicated secret and update
+> `deploy-web-smarterasp.yml` accordingly.
+
 ---
 
 ## Run in development

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -265,6 +265,24 @@ job - publish and deploy only happen if it passes.
 > site is actually on a different server, add a dedicated secret and update
 > `deploy-web-smarterasp.yml` accordingly.
 
+## Cutting a manual combined release
+
+`.github/workflows/release.yml` is a separate, manual release path: push a tag like `v1.2.3` and it
+builds + zips **both** `VaultGuard.API` and `VaultGuard.Web` (self-contained, `win-x64`), creates a
+`release/v1.2.3` branch off that commit, and publishes a GitHub Release with both zips attached -
+no deploy involved, just a combined build artifact + release.
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+This is separate from the automatic per-deploy releases described above (`api-vX.Y.Z` / `web-vX.Y.Z`,
+created automatically on every successful SmarterASP.NET deploy, no manual tagging needed).
+`build-api.yml`/`build-web.yml` also each build+zip+release their own project individually on a `v*` tag
+push (without a release branch) - all three contribute files to the same GitHub Release for a given tag
+rather than conflicting, but a `v*` tag does trigger three workflow runs.
+
 ---
 
 ## Run in development

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -211,7 +211,17 @@ if those tests pass**; a failure stops the job before anything reaches the serve
 publish output, so the SmarterASP.NET server doesn't need a matching runtime installed. Combined with
 `VaultGuard.API.csproj`'s `AspNetCoreHostingModel=OutOfProcess` (already set to match SmarterASP.NET's
 shared IIS app-pool constraints), `dotnet publish` generates the right `web.config` for IIS/ANCM to run
-the self-contained executable.
+the self-contained executable. `-p:Version=` stamps the computed version into the assembly, which is what
+makes it show up live in Scalar's title badge and `/swagger/v1/swagger.json` (see `Program.cs`'s
+`AddSwaggerGen` call).
+
+**Versioning and releases are fully automatic** - no manual `git tag && git push` needed. Once the deploy
+above succeeds, the job:
+1. Computes the next version by reading the highest existing `api-vX.Y.Z` tag and bumping the patch
+   number (starts at `1.0.0` if none exist yet).
+2. Tags the exact commit that was deployed and pushes the tag.
+3. Creates a `release/api-vX.Y.Z` branch off that same commit.
+4. Zips the publish output and attaches it to a new GitHub Release for that tag.
 
 **Required GitHub repo secrets** (Settings → Secrets and variables → Actions) - values come from your
 SmarterASP.NET control panel's Web Deploy settings:
@@ -232,7 +242,10 @@ SmarterASP.NET control panel's Web Deploy settings:
 
 `.github/workflows/deploy-web-smarterasp.yml` mirrors the API workflow above for **only**
 `VaultGuard.Web` (the Blazor Server web app) - same action, same self-contained `win-x64` publish, same
-`AspNetCoreHostingModel=OutOfProcess` reasoning (already set in `VaultGuard.Web.csproj`).
+`AspNetCoreHostingModel=OutOfProcess` reasoning (already set in `VaultGuard.Web.csproj`), and the same
+automatic version bump → tag (`web-vX.Y.Z`) → `release/web-vX.Y.Z` branch → zipped GitHub Release cycle
+once the deploy succeeds. `-p:Version=` stamps the assembly version that Settings → About displays
+(`VaultGuard.Web/Components/Pages/Settings.razor`'s `_appVersion`).
 
 **When it runs:** on every pull request into `devmain` that touches Web-relevant code (`VaultGuard.Web`,
 `VaultGuard.Components.Shared`, or the web test project). `VaultGuard.Web.Tests` runs first in the same

--- a/VaultGuard.API/Program.cs
+++ b/VaultGuard.API/Program.cs
@@ -311,7 +311,18 @@ builder.Services.AddScoped<Fido2NetLib.IFido2>(provider =>
 
 // Add API documentation with Swagger (compatible with .NET 8)
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    // Reads the assembly's actual version instead of Swashbuckle's hardcoded "1.0" default, so the
+    // version shown here (Scalar's title badge, /swagger/v1/swagger.json) tracks whatever -p:Version=
+    // was stamped in at publish time (see .github/workflows/deploy-api-smarterasp.yml).
+    var apiVersion = typeof(Program).Assembly.GetName().Version?.ToString(3) ?? "1.0.0";
+    c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+    {
+        Title = builder.Configuration["ApiSettings:Title"] ?? "Vault Guard API",
+        Version = apiVersion
+    });
+});
 
 // Add CORS — restrict to an explicit allow-list instead of AllowAnyOrigin. Origins come from the
 // "Cors:AllowedOrigins" config array (set per environment); the default covers local dev only.

--- a/VaultGuard.Web/Components/Pages/Settings.razor
+++ b/VaultGuard.Web/Components/Pages/Settings.razor
@@ -1314,8 +1314,9 @@
         finally { _dbBusy = false; }
     }
 
-    // About
-    readonly string _appVersion = "1.0.0";
+    // About - reads the assembly's actual version instead of a hardcoded literal, so it tracks whatever
+    // -p:Version= was stamped in at publish time (see .github/workflows/deploy-web-smarterasp.yml).
+    readonly string _appVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.0.0";
     readonly string _buildDate = System.DateTime.UtcNow.Year.ToString();
     string _updateManifestUrl = string.Empty;
     string _sentryDsn = string.Empty;


### PR DESCRIPTION
## Summary

- **New:** `.github/workflows/deploy-web-smarterasp.yml` - deploys **only** `VaultGuard.Web` (Blazor
  Server) to SmarterASP.NET, mirroring the API deploy workflow (same Web Deploy action, self-contained
  `win-x64` publish, gated on `VaultGuard.Web.Tests` passing first). Uses `BLAZORUSERNAME`/
  `BLAZORPASSWORD`/`BLAZORSITENAME` secrets, reusing `APISERVER` for the server address.
- **Both deploy workflows now fully automate versioning and releases** after a successful deploy:
  1. Compute the next patch version from the highest existing `api-v*`/`web-v*` tag (starts at `1.0.0`).
  2. Stamp it in via `-p:Version=` - which now actually shows up live: `VaultGuard.API`'s Swagger/Scalar
     doc reads the assembly version instead of Swashbuckle's hardcoded `"1.0"`, and `VaultGuard.Web`'s
     Settings → About tab reads it instead of a hardcoded `"1.0.0"` literal.
  3. Tag the exact deployed commit and push it.
  4. Create and push a `release/{api,web}-vX.Y.Z` branch off that commit.
  5. Zip the publish output and attach it to a new GitHub Release.

No manual `git tag && git push` step required anywhere in this cycle.

`ReadMe.md` documents both workflows, their secrets, and the automated version/tag/branch/release cycle.

## Test plan

- [x] Both workflow YAMLs validated (`yaml.safe_load`).
- [x] `VaultGuard.API` and `VaultGuard.Web` both build clean with the `Program.cs`/`Settings.razor`
      version changes.
- [x] Confirmed `-p:Version=X.Y.Z` actually stamps the assembly version as expected (built a throwaway
      test harness that loaded the compiled DLL and read `Assembly.GetName().Version`).
- [ ] First real PR run against `devmain` is the one to watch for the actual tag/branch/release cycle
      end-to-end.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBEpcUwLtXxNprUfjha2ML)_