### PR TITLE
Fix Allure history cleanup permission failure in run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -110,9 +110,14 @@ jobs:
     # allure-report as a submodule gitlink instead of plain files, which has no .gitmodules entry and
     # breaks GitHub's own Pages build (fails checkout with "No url found for submodule path
     # 'allure-report'") - so the live site stops updating even though every workflow here reports success.
+    #
+    # sudo is required: allure-report-action runs inside a Docker container, so the files it writes into
+    # allure-history/.git are root-owned - a plain `rm -rf` as the runner's non-root user fails with
+    # "Permission denied" on every file, which fails this step (and so the whole job) even though every
+    # actual test passed.
     - name: Strip nested git metadata from Allure history
       if: always()
-      run: rm -rf allure-history/.git
+      run: sudo rm -rf allure-history/.git
 
     # destination_dir + keep_files so this coexists with the docs site (build-docs.yml), which also
     # publishes to gh-pages but at the branch root - without keep_files, each publish wipes the branch


### PR DESCRIPTION
## Summary
PR #468 merged before this fix was ready, so `devmain`'s `run-tests.yml` still has the broken step - confirmed by the push-triggered run right after that merge (`372a09c`) failing the same way.

- `simple-elf/allure-report-action` runs inside a Docker container, so the `allure-history/.git` files it copies over are root-owned.
- The `rm -rf allure-history/.git` step added in #466 (to fix the GitHub Pages gitlink issue) failed with `Permission denied` on every file as the runner's regular non-root user, exiting 1 - which failed the whole `Run Unit Tests` job even though **all 245 actual test results passed**. This is what showed up as "unit tests failing" even though nothing was actually broken.
- Fix: `sudo rm -rf allure-history/.git` - passwordless `sudo` is available on GitHub-hosted runners and can remove root-owned files.

## Test plan
- [x] Confirmed via job logs (run `29662786353`) that every actual test suite passed and the only failure was this `rm -rf` step's exit code.
- [ ] After merge: confirm the push-triggered `run-tests.yml` run goes fully green and the Allure dashboard finally publishes to `https://dotnetappdev.github.io/PasswordManagerApp/allure-report/` (currently 404s).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBEpcUwLtXxNprUfjha2ML)_