### PR TITLE
Trigger Allure publish re-run after manual gh-pages gitlink cleanup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -114,7 +114,8 @@ jobs:
     # sudo is required: allure-report-action runs inside a Docker container, so the files it writes into
     # allure-history/.git are root-owned - a plain `rm -rf` as the runner's non-root user fails with
     # "Permission denied" on every file, which fails this step (and so the whole job) even though every
-    # actual test passed.
+    # actual test passed. (A run before this fix landed left allure-report as a stale gitlink on
+    # gh-pages, which was cleaned up manually so this step's fix could take effect.)
     - name: Strip nested git metadata from Allure history
       if: always()
       run: sudo rm -rf allure-history/.git


### PR DESCRIPTION
## Summary
The push run right after #468 merged (before the sudo fix in #469 landed) failed partway through stripping `allure-history/.git`, and its Allure publish step still committed `allure-report` as a submodule gitlink on `gh-pages` again. That poisoned the path for every subsequent publish - confirmed via job logs for the first post-#469 push run: `peaceiris/actions-gh-pages` cloned fresh, copied real files into `allure-report/`, ran `git add --all`, and got `nothing to commit, working tree clean` / `Everything up-to-date`, because git's index already had that path recorded as a gitlink and silently refuses to stage plain files under it.

I removed the stale gitlink directly on `gh-pages` (same fix as #466, one-time cleanup). This PR is a trivial comment-only change to `run-tests.yml` whose real purpose is to trigger a fresh push-triggered run against the now-clean `gh-pages`, so the Allure publish can finally populate `allure-report/` with real files.

My GitHub integration doesn't have permission to use `workflow_dispatch` or re-run an existing workflow run directly (`403 Resource not accessible by integration`), so a real content push is the only way to trigger this.

## Test plan
- [x] Confirmed via job logs that `git add --all` was silently a no-op due to the stale gitlink.
- [x] Removed the gitlink from `gh-pages` directly.
- [ ] After merge: confirm the push-triggered run publishes real files to `allure-report/` (not a gitlink) and `https://dotnetappdev.github.io/PasswordManagerApp/allure-report/` returns 200.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBEpcUwLtXxNprUfjha2ML)_