### PR TITLE
Fix Allure dashboard redirect URL (404 on landing page)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -94,6 +94,12 @@ jobs:
         ref: gh-pages
         path: gh-pages
 
+    # report_url overrides the base URL the action uses to build allure-history/index.html's redirect.
+    # Without it, the action assumes the report is published at the repo root and generates
+    # ".../PasswordManagerApp/<run>/index.html" - but the publish step below actually places it under
+    # destination_dir: allure-report, so that redirect 404s (there's no /<run>/ at the site root). This
+    # makes the redirect target ".../PasswordManagerApp/allure-report/<run>/index.html", which matches
+    # where the file actually ends up.
     - name: Build Allure report
       uses: simple-elf/allure-report-action@master
       if: always()
@@ -104,6 +110,7 @@ jobs:
         allure_report: allure-report
         keep_reports: 20
         gh_pages: gh-pages
+        report_url: https://dotnetappdev.github.io/PasswordManagerApp/allure-report
 
     # allure-report-action populates allure-history from the "gh-pages" checkout above (path: gh-pages),
     # which brings that checkout's .git along with it. Left in place, peaceiris/actions-gh-pages records


### PR DESCRIPTION
## Summary
Found the actual reason the Allure dashboard still 404s for real users, despite `allure-report/` and `allure-report/<run>/index.html` both individually returning HTTP 200.

`allure-report/index.html` is a meta-refresh redirect stub generated by `simple-elf/allure-report-action`. It currently points to:
```
https://dotnetappdev.github.io/PasswordManagerApp/37/index.html
```
which 404s (confirmed) - because the action assumes the report is published at the site root and builds the redirect from that assumption, but our `destination_dir: allure-report` in the publish step actually nests everything one level deeper. The correct path is:
```
https://dotnetappdev.github.io/PasswordManagerApp/allure-report/37/index.html
```
which returns 200 (also confirmed) - it's just never what the redirect sends you to.

So the flow every visitor hits is: land on `allure-report/` → real 200 page loads → its embedded meta-refresh immediately fires → browser navigates to the wrong (root-level) URL → that 404s → VitePress's docs-site 404 page renders. This is exactly what was reported and confirmed by a screenshot.

Fix: added `report_url: https://dotnetappdev.github.io/PasswordManagerApp/allure-report` to the `simple-elf/allure-report-action` step - traced through the action's `entrypoint.sh` source to confirm this input overrides only the base URL used for the redirect, without touching any of the existing folder-resolution inputs (`allure_history`, `gh_pages`, etc.), so nothing else about the publish changes.

## Test plan
- [x] Confirmed via `curl` that the redirect target 404s and the real (correct) path returns 200.
- [x] Traced `simple-elf/allure-report-action`'s source to find the exact mechanism (`report_url` input) and confirm it only affects redirect URL construction.
- [ ] After merge: confirm the next push-triggered run regenerates `allure-report/index.html` with the corrected redirect target, and that visiting `https://dotnetappdev.github.io/PasswordManagerApp/allure-report/` in a real browser lands on the actual dashboard instead of the docs-site 404 page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBEpcUwLtXxNprUfjha2ML)_