### PR TITLE
Add a third Allure grouping level (Story/SubSuite) for finer test categorization

### DIFF
--- a/VaultGuard.BackEnd.Tests/Controllers/ApiKeysControllerTests.cs
+++ b/VaultGuard.BackEnd.Tests/Controllers/ApiKeysControllerTests.cs
@@ -26,6 +26,8 @@ namespace VaultGuard.BackEnd.Tests.Controllers;
 [AllureFeature("API Keys")]
 [AllureParentSuite("Accounts & API Access")]
 [AllureSuite("API Keys")]
+[AllureStory("Controller Endpoints")]
+[AllureSubSuite("Controller Endpoints")]
 public class ApiKeysControllerTests
 {
     private Mock<IApiKeyService> _mockApiKeyService = null!;

--- a/VaultGuard.BackEnd.Tests/Controllers/CollectionsControllerTests.cs
+++ b/VaultGuard.BackEnd.Tests/Controllers/CollectionsControllerTests.cs
@@ -16,6 +16,8 @@ namespace VaultGuard.BackEnd.Tests.Controllers;
 [AllureFeature("Categories & Collections")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Categories & Collections")]
+[AllureStory("Collections Controller")]
+[AllureSubSuite("Collections Controller")]
 public class CollectionsControllerTests
 {
     private Mock<ICollectionApiService> _mockCollectionService = null!;

--- a/VaultGuard.BackEnd.Tests/Controllers/PasswordItemsControllerTests.cs
+++ b/VaultGuard.BackEnd.Tests/Controllers/PasswordItemsControllerTests.cs
@@ -28,6 +28,8 @@ namespace VaultGuard.BackEnd.Tests.Controllers;
 [AllureFeature("Password Items")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Password Items")]
+[AllureStory("Controller Endpoints")]
+[AllureSubSuite("Controller Endpoints")]
 public class PasswordItemsControllerTests
 {
     private Mock<IPasswordItemApiService> _mockItemService = null!;

--- a/VaultGuard.BackEnd.Tests/Controllers/UserProfileControllerTests.cs
+++ b/VaultGuard.BackEnd.Tests/Controllers/UserProfileControllerTests.cs
@@ -23,6 +23,8 @@ namespace VaultGuard.BackEnd.Tests.Controllers;
 [AllureFeature("User Profiles")]
 [AllureParentSuite("Accounts & API Access")]
 [AllureSuite("User Profiles")]
+[AllureStory("Controller Endpoints")]
+[AllureSubSuite("Controller Endpoints")]
 public class UserProfileControllerTests
 {
     private Mock<IUserProfileService> _mockUserProfileService = null!;

--- a/VaultGuard.BackEnd.Tests/Helpers/InputValidationHelperTests.cs
+++ b/VaultGuard.BackEnd.Tests/Helpers/InputValidationHelperTests.cs
@@ -14,6 +14,8 @@ namespace VaultGuard.BackEnd.Tests.Helpers;
 public class InputValidationHelperTests
 {
     [Test]
+    [AllureStory("Username Validation")]
+    [AllureSubSuite("Username Validation")]
     public void ValidateUsername_WithNullOrEmpty_ReturnsFalse()
     {
         // Arrange & Act
@@ -29,6 +31,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Username Validation")]
+    [AllureSubSuite("Username Validation")]
     public void ValidateUsername_WithSingleCharacter_ReturnsFalse()
     {
         // Arrange & Act
@@ -40,6 +44,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Username Validation")]
+    [AllureSubSuite("Username Validation")]
     public void ValidateUsername_WithIllegalCharacters_ReturnsFalse()
     {
         // Arrange & Act
@@ -55,6 +61,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Username Validation")]
+    [AllureSubSuite("Username Validation")]
     public void ValidateUsername_WithLegalCharacters_ReturnsTrue()
     {
         // Arrange & Act
@@ -71,6 +79,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Password Length Validation")]
+    [AllureSubSuite("Password Length Validation")]
     public void ValidatePassword_WithNullOrEmpty_ReturnsFalse()
     {
         // Arrange & Act
@@ -86,6 +96,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Password Length Validation")]
+    [AllureSubSuite("Password Length Validation")]
     public void ValidatePassword_WithSingleCharacter_ReturnsFalse()
     {
         // Arrange & Act
@@ -97,6 +109,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Password Length Validation")]
+    [AllureSubSuite("Password Length Validation")]
     public void ValidatePassword_WithValidLength_ReturnsTrue()
     {
         // Arrange & Act
@@ -107,6 +121,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Master Password Strength Rules")]
+    [AllureSubSuite("Master Password Strength Rules")]
     public void ValidateMasterPassword_WithShortPassword_ReturnsFalse()
     {
         // Arrange & Act
@@ -122,6 +138,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Master Password Strength Rules")]
+    [AllureSubSuite("Master Password Strength Rules")]
     public void ValidateMasterPassword_WithoutUppercase_ReturnsFalse()
     {
         // Arrange & Act
@@ -133,6 +151,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Master Password Strength Rules")]
+    [AllureSubSuite("Master Password Strength Rules")]
     public void ValidateMasterPassword_WithoutLowercase_ReturnsFalse()
     {
         // Arrange & Act
@@ -144,6 +164,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Master Password Strength Rules")]
+    [AllureSubSuite("Master Password Strength Rules")]
     public void ValidateMasterPassword_WithoutDigit_ReturnsFalse()
     {
         // Arrange & Act
@@ -155,6 +177,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Master Password Strength Rules")]
+    [AllureSubSuite("Master Password Strength Rules")]
     public void ValidateMasterPassword_WithAllRequirements_ReturnsTrue()
     {
         // Arrange & Act
@@ -166,6 +190,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Name Validation")]
+    [AllureSubSuite("Name Validation")]
     public void ValidateName_WithNullOrEmpty_ReturnsFalse()
     {
         // Arrange & Act
@@ -181,6 +207,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Name Validation")]
+    [AllureSubSuite("Name Validation")]
     public void ValidateName_WithSingleCharacter_ReturnsFalse()
     {
         // Arrange & Act
@@ -192,6 +220,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Name Validation")]
+    [AllureSubSuite("Name Validation")]
     public void ValidateName_WithIllegalCharacters_ReturnsFalse()
     {
         // Arrange & Act
@@ -207,6 +237,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Name Validation")]
+    [AllureSubSuite("Name Validation")]
     public void ValidateName_WithLegalCharacters_ReturnsTrue()
     {
         // Arrange & Act
@@ -223,6 +255,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Email Validation")]
+    [AllureSubSuite("Email Validation")]
     public void ValidateEmail_WithNullOrEmpty_ReturnsFalse()
     {
         // Arrange & Act
@@ -238,6 +272,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Email Validation")]
+    [AllureSubSuite("Email Validation")]
     public void ValidateEmail_WithTooShort_ReturnsFalse()
     {
         // Arrange & Act
@@ -249,6 +285,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Email Validation")]
+    [AllureSubSuite("Email Validation")]
     public void ValidateEmail_WithInvalidFormat_ReturnsFalse()
     {
         // Arrange & Act
@@ -265,6 +303,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Email Validation")]
+    [AllureSubSuite("Email Validation")]
     public void ValidateEmail_WithValidFormat_ReturnsTrue()
     {
         // Arrange & Act
@@ -279,6 +319,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Password Confirmation Matching")]
+    [AllureSubSuite("Password Confirmation Matching")]
     public void ValidatePasswordMatch_WithMatchingPasswords_ReturnsTrue()
     {
         // Arrange & Act
@@ -290,6 +332,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Password Confirmation Matching")]
+    [AllureSubSuite("Password Confirmation Matching")]
     public void ValidatePasswordMatch_WithDifferentPasswords_ReturnsFalse()
     {
         // Arrange & Act
@@ -301,6 +345,8 @@ public class InputValidationHelperTests
     }
 
     [Test]
+    [AllureStory("Password Confirmation Matching")]
+    [AllureSubSuite("Password Confirmation Matching")]
     public void ValidatePasswordMatch_CaseSensitive_ReturnsFalse()
     {
         // Arrange & Act

--- a/VaultGuard.BackEnd.Tests/Services/ApiKeyServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/ApiKeyServiceTests.cs
@@ -27,6 +27,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("API Keys")]
 [AllureParentSuite("Accounts & API Access")]
 [AllureSuite("API Keys")]
+[AllureStory("Service Layer")]
+[AllureSubSuite("Service Layer")]
 public class ApiKeyServiceTests
 {
     private string _dbName = null!;

--- a/VaultGuard.BackEnd.Tests/Services/CategoryServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/CategoryServiceTests.cs
@@ -17,6 +17,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Categories & Collections")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Categories & Collections")]
+[AllureStory("Categories Service")]
+[AllureSubSuite("Categories Service")]
 public class CategoryServiceTests
 {
     private DbContextOptions<VaultGuardDbContext> _options = null!;

--- a/VaultGuard.BackEnd.Tests/Services/CollectionServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/CollectionServiceTests.cs
@@ -15,6 +15,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Categories & Collections")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Categories & Collections")]
+[AllureStory("Collections Service")]
+[AllureSubSuite("Collections Service")]
 public class CollectionServiceTests
 {
     private DbContextOptions<VaultGuardDbContext> _options = null!;

--- a/VaultGuard.BackEnd.Tests/Services/CryptographyEdgeCaseTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/CryptographyEdgeCaseTests.cs
@@ -18,6 +18,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Encryption & Key Derivation")]
 [AllureParentSuite("Cryptography & Security")]
 [AllureSuite("Encryption & Key Derivation")]
+[AllureStory("Boundary & Edge Cases")]
+[AllureSubSuite("Boundary & Edge Cases")]
 public class CryptographyEdgeCaseTests
 {
     private CryptographyService _crypto = null!;

--- a/VaultGuard.BackEnd.Tests/Services/CryptographyTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/CryptographyTests.cs
@@ -20,6 +20,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Encryption & Key Derivation")]
 [AllureParentSuite("Cryptography & Security")]
 [AllureSuite("Encryption & Key Derivation")]
+[AllureStory("Happy-Path Round Trips")]
+[AllureSubSuite("Happy-Path Round Trips")]
 public class CryptographyTests
 {
     private CryptographyService _crypto = null!;

--- a/VaultGuard.BackEnd.Tests/Services/JwtServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/JwtServiceTests.cs
@@ -66,6 +66,8 @@ public class JwtServiceTests
     // ── GenerateToken ──────────────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Token Generation")]
+    [AllureSubSuite("Token Generation")]
     public void GenerateToken_ProducesWellFormedJwtWithExpectedClaims()
     {
         var user = NewUser();
@@ -84,6 +86,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Token Generation")]
+    [AllureSubSuite("Token Generation")]
     public void GenerateToken_TwoCallsForSameUser_ProduceDifferentTokens()
     {
         var user = NewUser();
@@ -93,6 +97,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Token Generation")]
+    [AllureSubSuite("Token Generation")]
     public void GenerateToken_MissingNames_TrimsToEmptyNameClaim()
     {
         var user = NewUser();
@@ -108,6 +114,8 @@ public class JwtServiceTests
     // ── GenerateRefreshToken ───────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Refresh Token Generation")]
+    [AllureSubSuite("Refresh Token Generation")]
     public void GenerateRefreshToken_ProducesNonEmptyBase64String()
     {
         var token = _jwtService.GenerateRefreshToken();
@@ -116,6 +124,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Refresh Token Generation")]
+    [AllureSubSuite("Refresh Token Generation")]
     public void GenerateRefreshToken_VariesPerCall()
     {
         var a = _jwtService.GenerateRefreshToken();
@@ -126,6 +136,8 @@ public class JwtServiceTests
     // ── GetPrincipalFromExpiredToken ──────────────────────────────────────────
 
     [Test]
+    [AllureStory("Expired Token Decoding")]
+    [AllureSubSuite("Expired Token Decoding")]
     public void GetPrincipalFromExpiredToken_AcceptsAnAlreadyExpiredToken()
     {
         var user = NewUser();
@@ -138,6 +150,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Expired Token Decoding")]
+    [AllureSubSuite("Expired Token Decoding")]
     public void GetPrincipalFromExpiredToken_WrongSigningKey_Throws()
     {
         var user = NewUser();
@@ -153,6 +167,8 @@ public class JwtServiceTests
     // ── CreateAuthResponseAsync ────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Auth Response Assembly")]
+    [AllureSubSuite("Auth Response Assembly")]
     public async Task CreateAuthResponseAsync_ReturnsPopulatedResponse_AndPersistsTheRefreshToken()
     {
         var user = NewUser();
@@ -170,12 +186,16 @@ public class JwtServiceTests
     // ── ValidateRefreshTokenAsync / SaveRefreshTokenAsync / RevokeRefreshTokenAsync ──
 
     [Test]
+    [AllureStory("Refresh Token Store")]
+    [AllureSubSuite("Refresh Token Store")]
     public async Task ValidateRefreshTokenAsync_UnknownUser_ReturnsFalse()
     {
         Assert.That(await _jwtService.ValidateRefreshTokenAsync(Guid.NewGuid().ToString(), "some-token"), Is.False);
     }
 
     [Test]
+    [AllureStory("Refresh Token Store")]
+    [AllureSubSuite("Refresh Token Store")]
     public async Task ValidateRefreshTokenAsync_KnownUserWrongToken_ReturnsFalse()
     {
         var userId = Guid.NewGuid().ToString();
@@ -185,6 +205,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Refresh Token Store")]
+    [AllureSubSuite("Refresh Token Store")]
     public async Task SaveRefreshTokenAsync_ThenValidate_RoundTrips()
     {
         var userId = Guid.NewGuid().ToString();
@@ -196,6 +218,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Refresh Token Store")]
+    [AllureSubSuite("Refresh Token Store")]
     public async Task SaveRefreshTokenAsync_KeepsOnlyTheLastFiveTokensPerUser()
     {
         var userId = Guid.NewGuid().ToString();
@@ -214,6 +238,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Refresh Token Store")]
+    [AllureSubSuite("Refresh Token Store")]
     public async Task RevokeRefreshTokenAsync_RemovesTheToken()
     {
         var userId = Guid.NewGuid().ToString();
@@ -226,6 +252,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Refresh Token Store")]
+    [AllureSubSuite("Refresh Token Store")]
     public async Task RevokeRefreshTokenAsync_DoesNotAffectOtherTokensForSameUser()
     {
         var userId = Guid.NewGuid().ToString();
@@ -241,6 +269,8 @@ public class JwtServiceTests
     }
 
     [Test]
+    [AllureStory("Refresh Token Store")]
+    [AllureSubSuite("Refresh Token Store")]
     public void RevokeRefreshTokenAsync_UnknownUserOrToken_DoesNotThrow()
     {
         Assert.DoesNotThrowAsync(async () =>

--- a/VaultGuard.BackEnd.Tests/Services/PassphraseGeneratorEdgeCaseTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/PassphraseGeneratorEdgeCaseTests.cs
@@ -20,6 +20,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Password Strength & Generation")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Password Strength & Generation")]
+[AllureStory("Passphrase Generator - Edge Cases")]
+[AllureSubSuite("Passphrase Generator - Edge Cases")]
 public class PassphraseGeneratorEdgeCaseTests
 {
     private PassphraseGenerator _gen = null!;

--- a/VaultGuard.BackEnd.Tests/Services/PassphraseGeneratorTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/PassphraseGeneratorTests.cs
@@ -12,6 +12,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Password Strength & Generation")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Password Strength & Generation")]
+[AllureStory("Passphrase Generator - Happy Path")]
+[AllureSubSuite("Passphrase Generator - Happy Path")]
 public class PassphraseGeneratorTests
 {
     private PassphraseGenerator _gen = null!;

--- a/VaultGuard.BackEnd.Tests/Services/PasswordCryptoServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/PasswordCryptoServiceTests.cs
@@ -36,6 +36,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Encryption")]
+    [AllureSubSuite("Encryption")]
     public void EncryptPassword_WithValidInputs_ShouldReturnEncryptedData()
     {
         // Arrange
@@ -69,6 +71,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Encryption")]
+    [AllureSubSuite("Encryption")]
     public void EncryptPassword_WithNullPassword_ShouldThrowArgumentException()
     {
         // Act & Assert
@@ -80,6 +84,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Encryption")]
+    [AllureSubSuite("Encryption")]
     public void EncryptPassword_WithEmptyPassword_ShouldThrowArgumentException()
     {
         // Act & Assert
@@ -91,6 +97,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Encryption")]
+    [AllureSubSuite("Encryption")]
     public void EncryptPassword_WithNullMasterPassword_ShouldThrowArgumentException()
     {
         // Act & Assert
@@ -102,6 +110,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Encryption")]
+    [AllureSubSuite("Encryption")]
     public void EncryptPassword_WithNullUserSalt_ShouldThrowArgumentException()
     {
         // Act & Assert
@@ -113,6 +123,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Encryption")]
+    [AllureSubSuite("Encryption")]
     public void EncryptPassword_WithEmptyUserSalt_ShouldThrowArgumentException()
     {
         // Act & Assert
@@ -124,6 +136,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Decryption")]
+    [AllureSubSuite("Decryption")]
     public void DecryptPassword_WithValidInputs_ShouldReturnOriginalPassword()
     {
         // Arrange
@@ -158,6 +172,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Decryption")]
+    [AllureSubSuite("Decryption")]
     public void DecryptPassword_WithNullEncryptedData_ShouldThrowArgumentNullException()
     {
         // Act & Assert
@@ -168,6 +184,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Decryption")]
+    [AllureSubSuite("Decryption")]
     public void DecryptPassword_WithInvalidBase64_ShouldThrowFormatException()
     {
         // Arrange
@@ -184,6 +202,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Salt Generation")]
+    [AllureSubSuite("Salt Generation")]
     public void GenerateUserSalt_ShouldReturnCorrectLength()
     {
         // Arrange
@@ -205,6 +225,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Master Password Hashing & Verification")]
+    [AllureSubSuite("Master Password Hashing & Verification")]
     public void CreateMasterPasswordHash_WithValidInputs_ShouldReturnHash()
     {
         // Arrange
@@ -232,6 +254,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Master Password Hashing & Verification")]
+    [AllureSubSuite("Master Password Hashing & Verification")]
     public void CreateMasterPasswordHash_WithNullMasterPassword_ShouldThrowArgumentException()
     {
         // Act & Assert
@@ -242,6 +266,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Master Password Hashing & Verification")]
+    [AllureSubSuite("Master Password Hashing & Verification")]
     public void VerifyMasterPassword_WithCorrectPassword_ShouldReturnTrue()
     {
         // Arrange
@@ -268,6 +294,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Master Password Hashing & Verification")]
+    [AllureSubSuite("Master Password Hashing & Verification")]
     public void VerifyMasterPassword_WithIncorrectPassword_ShouldReturnFalse()
     {
         // Arrange
@@ -294,6 +322,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Encryption")]
+    [AllureSubSuite("Encryption")]
     public void EncryptPassword_CryptographyServiceThrows_ShouldPropagateException()
     {
         // Arrange
@@ -309,6 +339,8 @@ public class PasswordCryptoServiceTests
     }
 
     [Test]
+    [AllureStory("Decryption")]
+    [AllureSubSuite("Decryption")]
     public void DecryptPassword_CryptographyServiceThrows_ShouldPropagateException()
     {
         // Arrange

--- a/VaultGuard.BackEnd.Tests/Services/PasswordItemServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/PasswordItemServiceTests.cs
@@ -15,6 +15,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Password Items")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Password Items")]
+[AllureStory("Service Layer")]
+[AllureSubSuite("Service Layer")]
 public class PasswordItemServiceTests
 {
     private DbContextOptions<VaultGuardDbContext> _options = null!;

--- a/VaultGuard.BackEnd.Tests/Services/PasswordStrengthServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/PasswordStrengthServiceTests.cs
@@ -12,6 +12,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Password Strength & Generation")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Password Strength & Generation")]
+[AllureStory("Password Strength Scoring")]
+[AllureSubSuite("Password Strength Scoring")]
 public class PasswordStrengthServiceTests
 {
     private PasswordStrengthService _service = null!;

--- a/VaultGuard.BackEnd.Tests/Services/ProtectedItemHelperTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/ProtectedItemHelperTests.cs
@@ -12,6 +12,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Password Items")]
 [AllureParentSuite("Vault Data Management")]
 [AllureSuite("Password Items")]
+[AllureStory("Protected-Field Encryption Helper")]
+[AllureSubSuite("Protected-Field Encryption Helper")]
 public class ProtectedItemHelperTests
 {
     [Test]

--- a/VaultGuard.BackEnd.Tests/Services/QrCodeServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/QrCodeServiceTests.cs
@@ -11,6 +11,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Two-Factor Authentication")]
 [AllureParentSuite("Cryptography & Security")]
 [AllureSuite("Two-Factor Authentication")]
+[AllureStory("QR Code Provisioning")]
+[AllureSubSuite("QR Code Provisioning")]
 public class QrCodeServiceTests
 {
     private QrCodeService _service = null!;

--- a/VaultGuard.BackEnd.Tests/Services/SeedingTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/SeedingTests.cs
@@ -79,6 +79,8 @@ public class SeedingTests
     // ── 1. Schema sanity ────────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Schema Guards")]
+    [AllureSubSuite("Schema Guards")]
     public void Schema_PasswordItemsTable_DoesNotHaveVaultIdColumn()
     {
         // [NotMapped] on PasswordItem.VaultId means EF Core must not create
@@ -101,6 +103,8 @@ public class SeedingTests
     }
 
     [Test]
+    [AllureStory("Schema Guards")]
+    [AllureSubSuite("Schema Guards")]
     public void Schema_CategoriesTable_DoesNotHaveVaultIdColumn()
     {
         using var cmd = _connection.CreateCommand();
@@ -118,6 +122,8 @@ public class SeedingTests
     // ── 2. Collections ──────────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Collection Seeding")]
+    [AllureSubSuite("Collection Seeding")]
     public void SeedCollections_OnEmptyDb_InsertsRows()
     {
         EnsureUser();
@@ -128,6 +134,8 @@ public class SeedingTests
     }
 
     [Test]
+    [AllureStory("Collection Seeding")]
+    [AllureSubSuite("Collection Seeding")]
     public void SeedCollections_CalledTwice_DoesNotDuplicate()
     {
         EnsureUser();
@@ -141,6 +149,8 @@ public class SeedingTests
     // ── 3. Categories ───────────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Category Seeding")]
+    [AllureSubSuite("Category Seeding")]
     public void SeedCategories_OnEmptyDb_InsertsRows()
     {
         EnsureUser();
@@ -151,6 +161,8 @@ public class SeedingTests
     }
 
     [Test]
+    [AllureStory("Category Seeding")]
+    [AllureSubSuite("Category Seeding")]
     public void SeedCategories_WithoutVaultId_DoesNotThrow()
     {
         EnsureUser();
@@ -163,6 +175,8 @@ public class SeedingTests
     // ── 4. Tags ─────────────────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Tag Seeding")]
+    [AllureSubSuite("Tag Seeding")]
     public void SeedTags_OnEmptyDb_InsertsRows()
     {
         EnsureUser();
@@ -175,6 +189,8 @@ public class SeedingTests
     // ── 5. Full pipeline ────────────────────────────────────────────────────
 
     [Test]
+    [AllureStory("Password Item Seeding")]
+    [AllureSubSuite("Password Item Seeding")]
     public void SeedPasswordItemsForUser_RequiresCollectionsCategoriesTags()
     {
         // Calling SeedPasswordItemsForUser WITHOUT seeding collections/categories/tags
@@ -199,6 +215,8 @@ public class SeedingTests
     }
 
     [Test]
+    [AllureStory("Full Pipeline & Referential Integrity")]
+    [AllureSubSuite("Full Pipeline & Referential Integrity")]
     public void FullSeedPipeline_CollectionsThenCategoriesThenTagsThenItems_Succeeds()
     {
         // This is the correct order: collections → categories → tags → items.
@@ -229,6 +247,8 @@ public class SeedingTests
     // ── 6. ForceSeedPasswordItems ───────────────────────────────────────────
 
     [Test]
+    [AllureStory("Password Item Seeding")]
+    [AllureSubSuite("Password Item Seeding")]
     public void ForceSeedPasswordItems_ClearsExistingThenReseeds()
     {
         EnsureUser();
@@ -252,6 +272,8 @@ public class SeedingTests
     }
 
     [Test]
+    [AllureStory("Password Item Seeding")]
+    [AllureSubSuite("Password Item Seeding")]
     public void ForceSeedPasswordItems_OnEmptyItemSet_Succeeds()
     {
         EnsureUser();
@@ -269,6 +291,8 @@ public class SeedingTests
     // ── 7. FK integrity after seeding ───────────────────────────────────────
 
     [Test]
+    [AllureStory("Full Pipeline & Referential Integrity")]
+    [AllureSubSuite("Full Pipeline & Referential Integrity")]
     public void SeededItems_CategoryIds_ReferenceExistingCategories()
     {
         EnsureUser();
@@ -292,6 +316,8 @@ public class SeedingTests
     }
 
     [Test]
+    [AllureStory("Full Pipeline & Referential Integrity")]
+    [AllureSubSuite("Full Pipeline & Referential Integrity")]
     public void SeededItems_CollectionIds_ReferenceExistingCollections()
     {
         EnsureUser();
@@ -317,6 +343,8 @@ public class SeedingTests
     // ── 8. SampleDataSeeder flow simulation ─────────────────────────────────
 
     [Test]
+    [AllureStory("Full Pipeline & Referential Integrity")]
+    [AllureSubSuite("Full Pipeline & Referential Integrity")]
     public void SampleDataSeederFlow_SeedsOnlyOncePerUser()
     {
         // Simulates what SampleDataSeeder.SeedSampleDataAsync does for a real user.

--- a/VaultGuard.BackEnd.Tests/Services/TotpHelperTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/TotpHelperTests.cs
@@ -12,6 +12,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Two-Factor Authentication")]
 [AllureParentSuite("Cryptography & Security")]
 [AllureSuite("Two-Factor Authentication")]
+[AllureStory("TOTP Helper Algorithms")]
+[AllureSubSuite("TOTP Helper Algorithms")]
 public class TotpHelperTests
 {
     private const string Secret = "GEZDGNBVGY3TQOJQ";

--- a/VaultGuard.BackEnd.Tests/Services/TotpServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/TotpServiceTests.cs
@@ -11,6 +11,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("Two-Factor Authentication")]
 [AllureParentSuite("Cryptography & Security")]
 [AllureSuite("Two-Factor Authentication")]
+[AllureStory("TOTP Service")]
+[AllureSubSuite("TOTP Service")]
 public class TotpServiceTests
 {
     private TotpService _service = null!;

--- a/VaultGuard.BackEnd.Tests/Services/UserProfileServiceTests.cs
+++ b/VaultGuard.BackEnd.Tests/Services/UserProfileServiceTests.cs
@@ -18,6 +18,8 @@ namespace VaultGuard.BackEnd.Tests.Services;
 [AllureFeature("User Profiles")]
 [AllureParentSuite("Accounts & API Access")]
 [AllureSuite("User Profiles")]
+[AllureStory("Service Layer")]
+[AllureSubSuite("Service Layer")]
 public class UserProfileServiceTests
 {
     private Mock<UserManager<ApplicationUser>> _mockUserManager = null!;

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -139,6 +139,25 @@ artifact instead, downloadable from that run's summary page.
   `Encryption & Key Derivation`, `Password Vault Cryptography`, `Two-Factor Authentication`,
   `Security Auditing`, `Input Validation`). Add all four attributes to a new fixture's class declaration
   to place it correctly in both tabs.
+- **A third level - `[AllureStory]` / `[AllureSubSuite]`:** Epic/Feature and ParentSuite/Suite are both
+  only two levels deep, so a Feature shared by several fixtures (e.g. `Password Items` held
+  `PasswordItemsControllerTests`, `PasswordItemServiceTests` and `ProtectedItemHelperTests` with no
+  further breakdown) or a single large fixture (e.g. `InputValidationHelperTests`, 23 tests in one flat
+  bucket) still didn't show any internal structure. `[AllureStory("...")]` / `[AllureSubSuite("...")]`
+  add a third tier under Feature/Suite respectively:
+  - **Class-level**, when a Feature bundles multiple fixtures - each fixture gets its own Story naming
+    its role (e.g. `Password Items` → `Controller Endpoints` / `Service Layer` /
+    `Protected-Field Encryption Helper`, one per fixture).
+  - **Method-level**, when a single fixture's tests cluster into distinct concerns - e.g.
+    `InputValidationHelperTests` splits into `Username Validation` / `Email Validation` /
+    `Master Password Strength Rules` / etc.; `JwtServiceTests` into `Token Generation` /
+    `Refresh Token Store` / etc. Allure applies the closest attribute to a test method, so a method-level
+    `[AllureStory]` overrides any class-level one - only add a class-level Story when *every* test in the
+    fixture genuinely belongs to it.
+
+  Not every fixture needs a Story - small, already-cohesive fixtures (a handful of tests covering one
+  method, e.g. `SecurityAuditServiceTests`) are left at Feature-level only; forcing a third tier there
+  would add noise, not clarity.
 - **Setup/teardown as named steps:** `[AllureNUnit]` alone does *not* surface `[SetUp]`/`[TearDown]` in
   the report - each one needs an explicit `[AllureBefore("description")]` / `[AllureAfter("description")]`
   attribute (placed above the `[SetUp]`/`[TearDown]` attribute) or it's invisible in the test's step


### PR DESCRIPTION
## Summary

Follow-up to #473 - the Behaviors/Suites tabs are only two levels deep (`Epic`/`Feature` and `ParentSuite`/`Suite`), so two shapes of test fixture in `VaultGuard.BackEnd.Tests` still showed no internal structure:

- A **Feature shared by several fixtures** - e.g. `Password Items` held `PasswordItemsControllerTests`, `PasswordItemServiceTests` and `ProtectedItemHelperTests` with no further breakdown.
- A **single large fixture** - e.g. `InputValidationHelperTests`, 23 tests in one flat bucket; `PasswordCryptoServiceTests`, 16; `JwtServiceTests`, 15; `SeedingTests`, 14.

Adds `[AllureStory]` / `[AllureSubSuite]` as a third tier under Feature/Suite (confirmed against Allure's NUnit docs - both attributes exist specifically for this):

- **Class-level**, for the 7 Features that bundle multiple fixtures - each fixture gets its own Story naming its role (`Controller Endpoints` / `Service Layer` / `Protected-Field Encryption Helper` / etc), covering 18 fixtures across `Cryptography & Security`, `Vault Data Management` and `Accounts & API Access`.
- **Method-level**, for 4 large single-fixture suites whose tests cluster into distinct concerns:
  - `PasswordCryptoServiceTests` → Encryption / Decryption / Salt Generation / Master Password Hashing & Verification
  - `InputValidationHelperTests` → Username / Password Length / Master Password Strength Rules / Name / Email / Password Confirmation Matching
  - `JwtServiceTests` → Token Generation / Refresh Token Generation / Expired Token Decoding / Auth Response Assembly / Refresh Token Store
  - `SeedingTests` → Schema Guards / Collection / Category / Tag / Password Item Seeding / Full Pipeline & Referential Integrity

Small, already-cohesive fixtures (a handful of tests covering one method, e.g. `SecurityAuditServiceTests`) are left at Feature-level only - forcing a third tier there would add noise, not clarity.

`docs/TESTING.md` updated to describe when and how to use Story/SubSuite.

## Test plan
- [x] Verified `AllureStory`/`AllureSubSuite` exist in Allure's NUnit attribute set (checked against official docs, not guessed) before using them.
- [x] Brace-balance checked across all 21 modified test files (no local `dotnet` available to compile-check).
- [x] Spot-checked that helper/private methods (e.g. `NewService`, `NewContext`, `[SetUp]`/`[TearDown]`) were not accidentally tagged - only methods explicitly mapped got the new attributes.
- [ ] After merge: confirm the Allure dashboard's Behaviors/Suites tabs show the new Story/SubSuite sub-grouping under the affected Features/Suites.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBEpcUwLtXxNprUfjha2ML)_