### PR TITLE
Cut a GitHub Release for all four apps on every PR merged into devmain

### DIFF
--- a/.github/workflows/build-maui.yml
+++ b/.github/workflows/build-maui.yml
@@ -8,6 +8,9 @@ on:
     branches: [ devmain, main ]
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+
 env:
   PROJECT: VaultGuard.App/VaultGuard.App.csproj
   DOTNET_VERSION: '10.0.x'
@@ -17,8 +20,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      # Explicit ref + full history: pull_request's default checkout is a synthetic merge commit that
+      # doesn't exist in the branch's real history (bad tag target), and the release version-bump
+      # below needs the full tag history, not the default shallow clone.
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -36,3 +45,64 @@ jobs:
       # look for a nonexistent win-x64 flavored Mono runtime pack (NU1102).
       - name: Build
         run: dotnet build ${{ env.PROJECT }} --configuration Release -f net10.0-windows10.0.19041.0
+
+      # ── Android release: on a merged PR into devmain (auto-versioned, mirrors deploy-api/web-
+      # smarterasp.yml's "android-vX.Y.Z" tag scheme) or a manual vX.Y.Z tag push. Gated separately
+      # from the Windows-head build above so it never affects that build's own trigger scope. ──────
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devmain')
+        id: ver
+        shell: bash
+        run: |
+          if [[ "${{ github.ref }}" =~ ^refs/tags/v(.+)$ ]]; then
+            ver="${BASH_REMATCH[1]}"
+            tag="${{ github.ref_name }}"
+          else
+            latest=$(git tag -l 'android-v*' | sed 's/^android-v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)
+            if [ -z "$latest" ]; then
+              ver="1.0.0"
+            else
+              IFS='.' read -r major minor patch <<< "$latest"
+              ver="$major.$minor.$((patch + 1))"
+            fi
+            tag="android-v$ver"
+          fi
+          echo "Resolved version: $ver (tag: $tag)"
+          echo "VERSION=$ver" >> "$GITHUB_OUTPUT"
+          echo "TAG=$tag" >> "$GITHUB_OUTPUT"
+
+      # No signing key is configured (see VaultGuard.App.csproj) - the SDK auto-generates a debug
+      # keystore, so this APK installs fine sideloaded ("install unknown apps") but isn't Play-Store
+      # signed. -f net10.0-android only (no -r/-p:RuntimeIdentifier) keeps this from leaking a Windows
+      # RID into Android's own restore, per the Build step's comment above.
+      - name: Publish Android APK
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devmain')
+        run: >
+          dotnet publish ${{ env.PROJECT }} -f net10.0-android --configuration Release
+          -p:Version=${{ steps.ver.outputs.VERSION }}
+          --output publish/android
+
+      # Only for the PR-merge case - a manual vX.Y.Z tag already exists (the user pushed it), so there's
+      # nothing to tag here; the release step below just attaches the APK to that existing tag's release.
+      - name: Tag release and create release branch
+        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devmain'
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          sha="${{ github.event.pull_request.head.sha }}"
+          git tag "${{ steps.ver.outputs.TAG }}" "$sha"
+          git push origin "${{ steps.ver.outputs.TAG }}"
+          git branch "release/${{ steps.ver.outputs.TAG }}" "$sha"
+          git push origin "release/${{ steps.ver.outputs.TAG }}"
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devmain')
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.ver.outputs.TAG }}
+          name: VaultGuard Android v${{ steps.ver.outputs.VERSION }}
+          generate_release_notes: true
+          files: publish/android/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wpf.yml
+++ b/.github/workflows/build-wpf.yml
@@ -8,6 +8,9 @@ on:
     branches: [ devmain, main ]
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+
 env:
   PROJECT: VaultGuard.WPF/VaultGuard.WPF.csproj
   PUBLISH_DIR: publish/wpf
@@ -18,26 +21,46 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      # Explicit ref + full history: pull_request's default checkout is a synthetic merge commit that
+      # doesn't exist in the branch's real history (bad tag target), and the release version-bump
+      # below needs the full tag history, not the default shallow clone.
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      # ── Derive version from git tag (v1.2.3) or use 0.0.0-dev ────────────
+      # ── Derive version: from a git tag (v1.2.3), auto-incremented from the latest wpf-vX.Y.Z tag on
+      # a merged PR into devmain (mirrors deploy-api/web-smarterasp.yml's scheme), or 0.0.0-dev
+      # otherwise (plain branch pushes/other PRs - build validation only, no release) ───────────────
       - name: Set version
         id: ver
-        shell: pwsh
+        shell: bash
         run: |
-          if ("${{ github.ref }}" -match "^refs/tags/v(.+)$") {
-            $ver = $matches[1]
-          } else {
-            $ver = "0.0.0-dev"
-          }
-          echo "VERSION=$ver" >> $env:GITHUB_OUTPUT
-          echo "Resolved version: $ver"
+          if [[ "${{ github.ref }}" =~ ^refs/tags/v(.+)$ ]]; then
+            ver="${BASH_REMATCH[1]}"
+            tag="${{ github.ref_name }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.base.ref }}" = "devmain" ]; then
+            latest=$(git tag -l 'wpf-v*' | sed 's/^wpf-v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)
+            if [ -z "$latest" ]; then
+              ver="1.0.0"
+            else
+              IFS='.' read -r major minor patch <<< "$latest"
+              ver="$major.$minor.$((patch + 1))"
+            fi
+            tag="wpf-v$ver"
+          else
+            ver="0.0.0-dev"
+            tag=""
+          fi
+          echo "VERSION=$ver" >> "$GITHUB_OUTPUT"
+          echo "TAG=$tag" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $ver (tag: $tag)"
 
       - name: Restore
         run: dotnet restore ${{ env.PROJECT }}
@@ -117,12 +140,27 @@ jobs:
           name: VaultGuard-MSI-${{ steps.ver.outputs.VERSION }}
           path: installer/output/*.msi
 
-      # ── Publish to GitHub Releases (tag builds only) ──────────────────────
+      # ── Publish to GitHub Releases: manual vX.Y.Z tag push, or a merged PR into devmain ──────────
+      # Only the PR-merge case needs a new tag - a manual vX.Y.Z tag already exists (the user pushed
+      # it), so there's nothing to create here; the release step below just attaches the installers to
+      # that existing tag's release.
+      - name: Tag release and create release branch
+        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devmain'
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          sha="${{ github.event.pull_request.head.sha }}"
+          git tag "${{ steps.ver.outputs.TAG }}" "$sha"
+          git push origin "${{ steps.ver.outputs.TAG }}"
+          git branch "release/${{ steps.ver.outputs.TAG }}" "$sha"
+          git push origin "release/${{ steps.ver.outputs.TAG }}"
+
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'devmain')
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ steps.ver.outputs.TAG }}
           name: VaultGuard ${{ steps.ver.outputs.VERSION }}
           generate_release_notes: true
           files: |

--- a/.github/workflows/deploy-api-smarterasp.yml
+++ b/.github/workflows/deploy-api-smarterasp.yml
@@ -103,7 +103,14 @@ jobs:
 
       # See ReadMe.md "Deploying the API to SmarterASP.NET" for where these come from in the
       # SmarterASP.NET control panel's Web Deploy settings.
+      # continue-on-error: SmarterASP.NET's Web Deploy target has been unreachable (DNS resolution
+      # failure) independent of anything in this repo - without this, a deploy outage silently blocks
+      # every step below forever, so no release ever gets cut even though the build/tests are fine.
+      # The release below reflects "this build passed tests and was published", not "this build is
+      # live on SmarterASP.NET" - check this step's own outcome for actual deploy status.
       - name: Deploy to SmarterASP.NET
+        id: deploy
+        continue-on-error: true
         uses: jahbenjah/SmarterASP.NET-web-deploy@1.0.0.alpha.8
         with:
           website-name: ${{ secrets.APISiteName }}
@@ -113,9 +120,13 @@ jobs:
           source-path: '${{ env.PUBLISH_DIR }}\'
           target-delete: 'true'
 
-      # Only reached if the deploy above succeeded: tag the deployed commit, branch off it, zip the
-      # publish output, and turn all of that into a GitHub Release - the whole tag/branch/release cycle
-      # runs here with no manual `git tag && git push` step needed.
+      - name: Warn if deploy failed
+        if: steps.deploy.outcome == 'failure'
+        run: echo "::warning::Deploy to SmarterASP.NET failed - releasing the build anyway, but it is NOT live on the server. Check the Deploy to SmarterASP.NET step above."
+
+      # Runs regardless of whether the deploy above succeeded (see continue-on-error note): tag the
+      # commit, branch off it, zip the publish output, and turn all of that into a GitHub Release - the
+      # whole tag/branch/release cycle runs here with no manual `git tag && git push` step needed.
       - name: Tag release and create release branch
         shell: bash
         run: |

--- a/.github/workflows/deploy-web-smarterasp.yml
+++ b/.github/workflows/deploy-web-smarterasp.yml
@@ -110,7 +110,14 @@ jobs:
       # SmarterASP.NET accounts commonly use one Web Deploy server address for every site/subdomain under
       # the same account, with only the site name/credentials differing per site. If the Blazor site is
       # actually on a different server, add a dedicated secret and swap it in here.
+      # continue-on-error: SmarterASP.NET's Web Deploy target has been unreachable (DNS resolution
+      # failure) independent of anything in this repo - without this, a deploy outage silently blocks
+      # every step below forever, so no release ever gets cut even though the build/tests are fine.
+      # The release below reflects "this build passed tests and was published", not "this build is
+      # live on SmarterASP.NET" - check this step's own outcome for actual deploy status.
       - name: Deploy to SmarterASP.NET
+        id: deploy
+        continue-on-error: true
         uses: jahbenjah/SmarterASP.NET-web-deploy@1.0.0.alpha.8
         with:
           website-name: ${{ secrets.BLAZORSITENAME }}
@@ -120,9 +127,13 @@ jobs:
           source-path: '${{ env.PUBLISH_DIR }}\'
           target-delete: 'true'
 
-      # Only reached if the deploy above succeeded: tag the deployed commit, branch off it, zip the
-      # publish output, and turn all of that into a GitHub Release - the whole tag/branch/release cycle
-      # runs here with no manual `git tag && git push` step needed.
+      - name: Warn if deploy failed
+        if: steps.deploy.outcome == 'failure'
+        run: echo "::warning::Deploy to SmarterASP.NET failed - releasing the build anyway, but it is NOT live on the server. Check the Deploy to SmarterASP.NET step above."
+
+      # Runs regardless of whether the deploy above succeeded (see continue-on-error note): tag the
+      # commit, branch off it, zip the publish output, and turn all of that into a GitHub Release - the
+      # whole tag/branch/release cycle runs here with no manual `git tag && git push` step needed.
       - name: Tag release and create release branch
         shell: bash
         run: |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -200,7 +200,8 @@ to the GitHub release. To build them locally, see [`installers/README.md`](insta
 ---
 
 > **Releasing?** See [`docs/RELEASING.md`](docs/RELEASING.md) for the full picture - the automatic
-> per-deploy releases below, the manual combined-tag release, and how to roll back to a previous one.
+> per-merge releases (all four apps) below, the manual combined-tag release, and how to roll back to
+> a previous one.
 
 ## Deploying the API to SmarterASP.NET
 
@@ -222,11 +223,15 @@ the self-contained executable. `-p:Version=` stamps the computed version into th
 makes it show up live in Scalar's title badge and `/swagger/v1/swagger.json` (see `Program.cs`'s
 `AddSwaggerGen` call).
 
-**Versioning and releases are fully automatic** - no manual `git tag && git push` needed. Once the deploy
-above succeeds, the job:
+**Versioning and releases are fully automatic** - no manual `git tag && git push` needed. The release
+step runs regardless of whether the deploy above actually succeeds (`continue-on-error: true` on that
+step - SmarterASP.NET's Web Deploy target being unreachable shouldn't block cutting a release for a
+build that passed its tests). Check the `Deploy to SmarterASP.NET` step's own outcome, or the
+`::warning::` it logs on failure, to see whether a given release is actually live on the server. The
+job:
 1. Computes the next version by reading the highest existing `api-vX.Y.Z` tag and bumping the patch
    number (starts at `1.0.0` if none exist yet).
-2. Tags the exact commit that was deployed and pushes the tag.
+2. Tags the commit from the PR's head and pushes the tag.
 3. Creates a `release/api-vX.Y.Z` branch off that same commit.
 4. Zips the publish output and attaches it to a new GitHub Release for that tag.
 
@@ -250,8 +255,9 @@ SmarterASP.NET control panel's Web Deploy settings:
 `.github/workflows/deploy-web-smarterasp.yml` mirrors the API workflow above for **only**
 `VaultGuard.Web` (the Blazor Server web app) - same action, same self-contained `win-x64` publish, same
 `AspNetCoreHostingModel=OutOfProcess` reasoning (already set in `VaultGuard.Web.csproj`), and the same
-automatic version bump → tag (`web-vX.Y.Z`) → `release/web-vX.Y.Z` branch → zipped GitHub Release cycle
-once the deploy succeeds. `-p:Version=` stamps the assembly version that Settings → About displays
+automatic version bump → tag (`web-vX.Y.Z`) → `release/web-vX.Y.Z` branch → zipped GitHub Release cycle,
+released regardless of whether the deploy itself succeeds (same `continue-on-error` reasoning as the API
+workflow above). `-p:Version=` stamps the assembly version that Settings → About displays
 (`VaultGuard.Web/Components/Pages/Settings.razor`'s `_appVersion`).
 
 **When it runs:** on every pull request into `devmain` that touches Web-relevant code (`VaultGuard.Web`,
@@ -272,20 +278,33 @@ job - publish and deploy only happen if it passes.
 > site is actually on a different server, add a dedicated secret and update
 > `deploy-web-smarterasp.yml` accordingly.
 
+## Android and WPF releases
+
+`build-maui.yml` (Android) and `build-wpf.yml` (WPF) follow the same automatic pattern as the API/Web
+workflows above - a merged pull request into `devmain` auto-versions (`android-vX.Y.Z` / `wpf-vX.Y.Z`,
+independently from the API/Web numbers), tags the commit, creates a matching `release/*` branch, and
+attaches the built artifact (an `.apk` for Android; an `.exe` and `.msi` installer for WPF) to a new
+GitHub Release. Neither has an external deploy step, so there's no `continue-on-error` concern - they
+release as soon as the build succeeds. See [`docs/RELEASING.md`](docs/RELEASING.md) for the full
+per-app trigger/tag table.
+
 ## Cutting a manual combined release
 
 `.github/workflows/release.yml` is a separate, manual release path: push a tag like `v1.2.3` and it
 builds + zips **both** `VaultGuard.API` and `VaultGuard.Web` (self-contained, `win-x64`), creates a
 `release/v1.2.3` branch off that commit, and publishes a GitHub Release with both zips attached -
-no deploy involved, just a combined build artifact + release.
+no deploy involved, just a combined build artifact + release. `build-api.yml`, `build-web.yml`,
+`build-maui.yml` and `build-wpf.yml` each also build+release their own project on the same `v*` tag,
+contributing an API zip, Web zip, Android APK, and WPF installers to that same release.
 
 ```bash
 git tag v1.2.3
 git push origin v1.2.3
 ```
 
-This is separate from the automatic per-deploy releases described above (`api-vX.Y.Z` / `web-vX.Y.Z`,
-created automatically on every successful SmarterASP.NET deploy, no manual tagging needed).
+This is separate from the automatic per-merge releases described above (`api-vX.Y.Z` / `web-vX.Y.Z` /
+`android-vX.Y.Z` / `wpf-vX.Y.Z`, created automatically on every PR merged into `devmain`, no manual
+tagging needed).
 `build-api.yml`/`build-web.yml` also each build+zip+release their own project individually on a `v*` tag
 push (without a release branch) - all three contribute files to the same GitHub Release for a given tag
 rather than conflicting, but a `v*` tag does trigger three workflow runs.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,31 +1,47 @@
 # Releasing VaultGuard
 
-There are two independent ways a release gets cut. Both end up as a tagged commit, a `release/*`
-branch, and a GitHub Release with a downloadable zip - the difference is what triggers them and
-whether anything gets deployed.
+There are two independent ways a release gets cut, covering all four shipped apps - **API, Blazor
+Web, Android, and WPF**. Both end up as a tagged commit, a `release/*` branch, and a GitHub Release
+with a downloadable artifact - the difference is what triggers them and whether anything gets
+deployed.
 
 📖 **Back to [Main README](../ReadMe.md)**
 
-## 1. Automatic releases on every SmarterASP.NET deploy
+## 1. Automatic releases on every merged pull request into `devmain`
 
-`.github/workflows/deploy-api-smarterasp.yml` and `.github/workflows/deploy-web-smarterasp.yml` each
-deploy one project (`VaultGuard.API` or `VaultGuard.Web`) and cut a release as a side effect - **you
-don't do anything manually for this path.**
+Each app has its own workflow that builds it and cuts a release as a side effect - **you don't do
+anything manually for this path**, it fires from a normal PR merge:
 
-**Trigger:** opening or updating a pull request into `devmain` that touches that project's code.
+| App | Workflow | Tag prefix | Artifact |
+| --- | --- | --- | --- |
+| API | `deploy-api-smarterasp.yml` | `api-v` | Self-contained `win-x64` zip |
+| Blazor Web | `deploy-web-smarterasp.yml` | `web-v` | Self-contained `win-x64` zip |
+| Android | `build-maui.yml` | `android-v` | `.apk` (debug-signed - see note below) |
+| WPF | `build-wpf.yml` | `wpf-v` | `.exe` (Inno Setup) + `.msi` (WiX) installers |
 
-**Gate:** the project's own unit tests (`VaultGuard.BackEnd.Tests` for the API,
-`VaultGuard.Web.Tests` for the web app) must pass in the same job. A test failure stops the job
-before publish/deploy/release ever run.
+**Trigger:** opening or updating a pull request into `devmain` that touches that app's code (API/Web
+are path-filtered to their own project's files; Android/WPF run on any PR into `devmain` or `main`,
+but only *release* when the PR targets `devmain`).
 
-Once the SmarterASP.NET deploy succeeds, the workflow:
+**Gate:** API/Web require their own unit tests (`VaultGuard.BackEnd.Tests` / `VaultGuard.Web.Tests`)
+to pass in the same job first - a test failure stops the job before publish/release ever run.
+Android/WPF release unconditionally on a successful build (they have no separate deploy step to
+gate on).
 
-1. Reads the highest existing `api-vX.Y.Z` (or `web-vX.Y.Z`) tag and bumps the patch number - starts
-   at `1.0.0` if neither exists yet. There's no version file to edit; the next number is always
-   computed from git tags.
-2. Tags the exact commit that was deployed and pushes the tag.
-3. Creates a `release/api-vX.Y.Z` (or `release/web-vX.Y.Z`) branch off that commit.
-4. Zips the self-contained publish output and attaches it to a new GitHub Release for that tag.
+For API/Web specifically, the release step is **not** gated on the SmarterASP.NET deploy actually
+succeeding (`continue-on-error: true` on that step) - a deploy outage (e.g. the SmarterASP.NET DNS
+issue) still produces a release, it just isn't live on the server yet. The job logs a `::warning::`
+on the deploy step when that happens, so check there if you need to know whether a given release
+actually made it onto SmarterASP.NET.
+
+Once the gate passes, each workflow:
+
+1. Reads the highest existing tag for its own prefix (`api-v`/`web-v`/`android-v`/`wpf-v`) and bumps
+   the patch number - starts at `1.0.0` if none exists yet. There's no version file to edit; the next
+   number is always computed from git tags, independently per app.
+2. Tags the exact commit from the PR's head and pushes the tag.
+3. Creates a matching `release/<prefix>vX.Y.Z` branch off that commit.
+4. Builds the artifact table above and attaches it to a new GitHub Release for that tag.
 
 The same `-p:Version=` that gets stamped into the published assembly is what makes the number show
 up live in the running apps:
@@ -39,11 +55,15 @@ up live in the running apps:
 See the ReadMe's "Deploying the API to SmarterASP.NET" / "Deploying the Web app to SmarterASP.NET"
 sections for the required secrets and hosting details.
 
+**Android signing note:** `VaultGuard.App.csproj` has no signing key configured, so `build-maui.yml`
+publishes with the SDK's auto-generated debug keystore. The resulting `.apk` installs fine sideloaded
+("install unknown apps") but isn't signed for the Play Store - add a real keystore + signing secrets
+to the workflow before treating these APKs as anything beyond internal/test builds.
+
 ## 2. Manual combined release
 
 `.github/workflows/release.yml` is the path to reach for when you want to cut a release by hand
-without going through a SmarterASP.NET deploy - it doesn't deploy anywhere, it just builds, zips, and
-publishes.
+without going through a merged PR - it doesn't deploy anywhere, it just builds, zips, and publishes.
 
 ```bash
 git tag v1.2.3
@@ -52,34 +72,36 @@ git push origin v1.2.3
 
 Pushing a `vX.Y.Z` tag:
 
-1. Creates a `release/v1.2.3` branch off that commit.
-2. Publishes **both** `VaultGuard.API` and `VaultGuard.Web` self-contained for `win-x64`, with
-   `-p:Version=1.2.3` stamped in (same About-tab/Scalar-badge effect as above).
-3. Zips each publish output separately (`VaultGuardAPI-1.2.3.zip`, `VaultGuardWeb-1.2.3.zip`).
-4. Publishes one GitHub Release for the `v1.2.3` tag with both zips attached.
+1. `release.yml` creates a `release/v1.2.3` branch off that commit, publishes **both**
+   `VaultGuard.API` and `VaultGuard.Web` self-contained for `win-x64` (`-p:Version=1.2.3` stamped
+   in), zips each separately (`VaultGuardAPI-1.2.3.zip`, `VaultGuardWeb-1.2.3.zip`), and publishes one
+   GitHub Release for the `v1.2.3` tag with both zips attached.
+2. `build-api.yml` and `build-web.yml` also each build+zip+release their own project individually on
+   the same tag (no release branch, no combined bundle).
+3. `build-maui.yml` and `build-wpf.yml` do the same for Android (`.apk`) and WPF (`.exe`/`.msi`).
 
-`build-api.yml` and `build-web.yml` also each build+zip+release their own project individually on
-any `v*` tag push (no release branch, no combined bundle) - all three workflows end up contributing
-files to the *same* GitHub Release for a given tag rather than conflicting, but a `v*` push does
-trigger three separate workflow runs. That's expected.
+All five workflows end up contributing files to the *same* GitHub Release for the `v1.2.3` tag rather
+than conflicting, but a `v*` push does trigger five separate workflow runs. That's expected.
 
 ## Picking a path
 
-- Cutting a release around **one specific project change**, or want it live on SmarterASP.NET
-  immediately? Just merge the PR into `devmain` - path 1 handles the rest.
-- Want a single **combined** release (both apps, one version number, no deploy) - e.g. for a
-  downloadable desktop/offline build, or to mark a milestone? Push a `vX.Y.Z` tag - path 2.
+- Cutting a release around **one specific app's change**, or want API/Web live on SmarterASP.NET
+  immediately? Just merge the PR into `devmain` - path 1 handles all four apps automatically, each
+  versioned independently.
+- Want a single **combined** release (all four apps, one shared version number) - e.g. to mark a
+  milestone? Push a `vX.Y.Z` tag - path 2.
 
-The two tag namespaces never collide (`api-v*` / `web-v*` vs `v*`), so both paths can run side by
-side without stepping on each other's version numbers.
+The tag namespaces never collide (`api-v*` / `web-v*` / `android-v*` / `wpf-v*` vs plain `v*`), so
+both paths can run side by side without stepping on each other's version numbers.
 
 ## Where to find things
 
 - **Releases:** repo → Releases tab, or `https://github.com/dotnetappdev/PasswordManagerApp/releases`.
-- **Tags:** `git tag -l 'api-v*'`, `git tag -l 'web-v*'`, or `git tag -l 'v*'`.
-- **Release branches:** `release/api-vX.Y.Z`, `release/web-vX.Y.Z`, `release/vX.Y.Z` - each is a
-  snapshot of the exact commit that was released, useful for a hotfix off an older release without
-  disturbing `devmain`.
+- **Tags:** `git tag -l 'api-v*'`, `git tag -l 'web-v*'`, `git tag -l 'android-v*'`,
+  `git tag -l 'wpf-v*'`, or `git tag -l 'v*'`.
+- **Release branches:** `release/api-vX.Y.Z`, `release/web-vX.Y.Z`, `release/android-vX.Y.Z`,
+  `release/wpf-vX.Y.Z`, `release/vX.Y.Z` - each is a snapshot of the exact commit that was released,
+  useful for a hotfix off an older release without disturbing `devmain`.
 
 ## Rolling back
 


### PR DESCRIPTION
## Summary

Releases weren't showing up because the only automatic path (API/Web) tags and releases as a side effect of a **successful SmarterASP.NET deploy** - and that deploy has been failing all session on an unrelated DNS issue, so the job never reached the release step. Android and WPF had no automatic release path at all (WPF only released on a manual version tag; Android never released anything - `build-maui.yml` only ever validated the Windows MAUI head, never built an APK).

- **`deploy-api-smarterasp.yml` / `deploy-web-smarterasp.yml`**: added `continue-on-error: true` to the `Deploy to SmarterASP.NET` step, so a deploy outage no longer blocks the release - it now reflects "build passed tests and was published", not "build is live on the server". A `::warning::` on the deploy step's own outcome tells you if it didn't actually reach SmarterASP.NET.
- **`build-maui.yml`**: added an Android APK publish (`net10.0-android`, no signing key configured so debug-signed/sideload-only) and release on a PR merged into `devmain`, auto-versioned from the highest `android-vX.Y.Z` tag - plus the same on a manual `vX.Y.Z` tag push, matching API/Web/WPF's existing pattern.
- **`build-wpf.yml`**: extended the existing tag-only release path to also fire on a PR merged into `devmain`, auto-versioned from the highest `wpf-vX.Y.Z` tag, attaching the existing EXE/MSI installers.

All four apps now version independently (`api-v*`/`web-v*`/`android-v*`/`wpf-v*`) and release on the same trigger: a PR landing in `devmain`.

`docs/RELEASING.md` and `ReadMe.md` updated to describe the unified scheme, including a trigger/tag/artifact table for all four apps.

## Test plan
- [x] All 4 modified workflow YAML files parse cleanly (`yaml.safe_load`, no local `dotnet`/`act` available to actually run them).
- [x] Verified `github.event.pull_request.base.ref` / `.head.sha` usage matches the exact pattern already proven working in `deploy-api-smarterasp.yml`/`deploy-web-smarterasp.yml` (leniently evaluates empty on non-PR events, consistent with existing `|| github.sha` fallbacks elsewhere in this repo).
- [x] Confirmed no signing key is configured in `VaultGuard.App.csproj`, so the new Android publish step's debug-signed APK is expected/documented, not a gap to silently fix.
- [ ] After merge: confirm this PR itself (once merged into `devmain`) actually produces four new releases (`api-v*`, `web-v*`, `android-v*`, `wpf-v*`) - this workflow doesn't touch any of the four apps' own code, so their existing path filters won't fire on this PR; the *next* PR that touches each app's code will be the first real end-to-end test per app.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBEpcUwLtXxNprUfjha2ML)_