### PR TITLE
Inline Allure screenshots + release Web/API zips on every PR

### DIFF
--- a/.github/workflows/deploy-api-smarterasp.yml
+++ b/.github/workflows/deploy-api-smarterasp.yml
@@ -1,25 +1,17 @@
 name: Deploy API to SmarterASP.NET
 
-# Deploys ONLY VaultGuard.API (the Web API project) to SmarterASP.NET via Web Deploy, and only when:
-#   1. A PR is opened/updated against devmain touching API-relevant code, AND
-#   2. VaultGuard.BackEnd.Tests (the unit tests that cover VaultGuard.API) pass.
-# The test step runs before publish/deploy in the same job, so a test failure stops the job there -
-# publish and deploy never run.
+# Deploys VaultGuard.API (the Web API project) to SmarterASP.NET via Web Deploy, and only when
+# VaultGuard.BackEnd.Tests (the unit tests that cover VaultGuard.API) pass. The test step runs before
+# publish/deploy in the same job, so a test failure stops the job there - publish and deploy never run.
+#
+# Runs on EVERY PR into devmain (no path filter) rather than only PRs touching API-relevant code, so an
+# api-vX.Y.Z release+zip gets cut alongside every other release (WPF/Android already do this
+# unconditionally - see build-wpf.yml/build-maui.yml) instead of only when the API itself changed. This
+# also means every PR into devmain now live-deploys the current devmain build of VaultGuard.API to the
+# production SmarterASP.NET site, whether or not that PR touched API code.
 on:
   pull_request:
     branches: [ devmain ]
-    paths:
-      - 'VaultGuard.API/**'
-      - 'VaultGuard.Models/**'
-      - 'VaultGuard.DAL/**'
-      - 'VaultGuard.Services/**'
-      - 'VaultGuard.Crypto/**'
-      - 'VaultGuard.DAL.SqlServer/**'
-      - 'VaultGuard.DAL.MySql/**'
-      - 'VaultGuard.DAL.Postgres/**'
-      - 'VaultGuard.DAL.SupaBase/**'
-      - 'VaultGuard.BackEnd.Tests/**'
-      - '.github/workflows/deploy-api-smarterasp.yml'
   workflow_dispatch: {}
 
 # Serializes runs for the same PR/branch (default cancel-in-progress: false, so a deploy already in

--- a/.github/workflows/deploy-web-smarterasp.yml
+++ b/.github/workflows/deploy-web-smarterasp.yml
@@ -1,29 +1,18 @@
 name: Deploy Web to SmarterASP.NET
 
-# Deploys ONLY VaultGuard.Web (the Blazor Server web app) to SmarterASP.NET via Web Deploy, and only
-# when:
-#   1. A PR is opened/updated against devmain touching Web-relevant code, AND
-#   2. VaultGuard.Web.Tests pass.
-# The test step runs before publish/deploy in the same job, so a test failure stops the job there -
-# publish and deploy never run. Mirrors deploy-api-smarterasp.yml - see that file/ReadMe.md for the
-# reasoning behind self-contained publish and the OutOfProcess hosting model.
+# Deploys VaultGuard.Web (the Blazor Server web app) to SmarterASP.NET via Web Deploy, and only when
+# VaultGuard.Web.Tests pass. The test step runs before publish/deploy in the same job, so a test failure
+# stops the job there - publish and deploy never run. Mirrors deploy-api-smarterasp.yml - see that
+# file/ReadMe.md for the reasoning behind self-contained publish and the OutOfProcess hosting model.
+#
+# Runs on EVERY PR into devmain (no path filter) rather than only PRs touching Web-relevant code, so a
+# web-vX.Y.Z release+zip gets cut alongside every other release (WPF/Android already do this
+# unconditionally - see build-wpf.yml/build-maui.yml) instead of only when Web itself changed. This also
+# means every PR into devmain now live-deploys the current devmain build of VaultGuard.Web to the
+# production SmarterASP.NET site, whether or not that PR touched Web code.
 on:
   pull_request:
     branches: [ devmain ]
-    paths:
-      - 'VaultGuard.Web/**'
-      - 'VaultGuard.Models/**'
-      - 'VaultGuard.Components.Shared/**'
-      - 'VaultGuard.DAL/**'
-      - 'VaultGuard.Services/**'
-      - 'VaultGuard.Crypto/**'
-      - 'VaultGuard.Imports/**'
-      - 'VaultGuard.DAL.SqlServer/**'
-      - 'VaultGuard.DAL.MySql/**'
-      - 'VaultGuard.DAL.Postgres/**'
-      - 'VaultGuard.DAL.SupaBase/**'
-      - 'VaultGuard.Web.Tests/**'
-      - '.github/workflows/deploy-web-smarterasp.yml'
   workflow_dispatch: {}
 
 # Serializes runs for the same PR/branch (default cancel-in-progress: false, so a deploy already in

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -160,17 +160,29 @@ jobs:
         reporter: dotnet-trx
         fail-on-error: true
 
-    - name: Upload Allure results artifact (raw .trx - Allure 2's trx-plugin reads it directly)
+    # SaveEvidenceAsync writes each screenshot's .png next to the trx (TestContext.TestResultsDirectory),
+    # and the trx's own <ResultFile> attachment entries point at those PNGs using a path relative to the
+    # trx's location. trx-plugin resolves that relative path itself, so for it to inline the screenshot
+    # (rather than just print the attachment's filename) the PNG has to land on disk exactly where the
+    # trx says it is - the whole blazor-ui-test-results tree is uploaded as ONE artifact, unflattened, so
+    # that relative layout survives the upload/download round-trip intact. (Two separate glob-filtered
+    # artifacts - one for *.trx, one for *.png - used to be uploaded here; GitHub's upload-artifact
+    # collapses each glob to its own common-ancestor directory, so the trx and its screenshots ended up
+    # at different relative depths after download and trx-plugin could never find the files it was
+    # pointed at - hence attachments rendering as a bare filename instead of an inline image.)
+    - name: Upload Allure results artifact (raw .trx + screenshots, same relative layout trx-plugin needs)
       uses: actions/upload-artifact@v7
       if: always()
       with:
         name: allure-results-blazor-ui
-        path: blazor-ui-test-results/**/blazor-ui-tests.trx
+        path: blazor-ui-test-results
         if-no-files-found: warn
         retention-days: 1
 
-    # if: always() so evidence from a failing run is downloadable too - that's the whole point of
-    # SaveEvidenceAsync, seeing what the page actually looked like when an assertion failed.
+    # Separate, longer-retention artifact purely for humans browsing screenshots directly without
+    # digging through the Allure dashboard - if: always() so evidence from a failing run is downloadable
+    # too, which is the whole point of SaveEvidenceAsync, seeing what the page actually looked like when
+    # an assertion failed.
     - name: Upload Blazor UI test screenshots
       uses: actions/upload-artifact@v7
       if: always()
@@ -182,11 +194,13 @@ jobs:
 
   # Combines both jobs above into the one Allure dashboard: the NUnit suites' native allure-results JSON
   # (rich Behaviors/Suites categorization, via [AllureNUnit]) and the Blazor UI (Playwright) suite's raw
-  # .trx (via Allure 2's own trx-plugin - see the "Publish Blazor UI Test Results" step's comment) sit
-  # side by side in one allure-results directory, so `allure generate` produces a single combined report
-  # instead of two separate ones. needs: [test, blazor-ui-tests] + if: always() so this still runs (and
-  # the dashboard still reflects reality) even if one of them fails - a failure is exactly what the
-  # dashboard exists to surface, not something to hide by skipping the publish step.
+  # .trx plus its screenshots (via Allure 2's own trx-plugin - see the "Upload Allure results artifact"
+  # step's comment on why the trx and PNGs have to be downloaded together, unflattened, for the
+  # screenshots to render inline instead of as bare filenames) sit side by side in one allure-results
+  # directory, so `allure generate` produces a single combined report instead of two separate ones.
+  # needs: [test, blazor-ui-tests] + if: always() so this still runs (and the dashboard still reflects
+  # reality) even if one of them fails - a failure is exactly what the dashboard exists to surface, not
+  # something to hide by skipping the publish step.
   publish-allure-report:
     runs-on: ubuntu-latest
     name: Publish Allure Report

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -295,6 +295,17 @@ Open `allure-report/index.html`. Both `allure-results/` and `allure-report/` are
   real browser and self-hosts `VaultGuard.Web`, several minutes slower than the NUnit-only default). Note
   this path gives per-test pass/fail/duration/error only, not the richer Behaviors/Suites categorization
   the NUnit suites get from their `[Allure*]` attributes - `trx-plugin` groups by the test class instead.
+  - **Screenshots render inline, not as filenames:** `BlazorWebTestBase.SaveEvidenceAsync` calls
+    `TestContext.AddResultFile`, which makes MSTest write each `.png` to disk next to the `.trx` and
+    record a `<ResultFile>` attachment entry pointing at it with a path relative to the `.trx`'s own
+    location. `trx-plugin` resolves that reference itself to inline the image on the test's page - so the
+    `.trx` and every `.png` it references have to keep that same relative layout wherever they end up. The
+    CI artifact (`allure-results-blazor-ui`) and the local script both upload/copy the whole
+    `blazor-ui-test-results` tree as a unit rather than pulling just the `.trx` out of it, precisely so
+    that layout survives intact; splitting the `.trx` and screenshots into separately-flattened
+    artifacts/copies (as this used to do) puts them at different relative depths, and `trx-plugin` then
+    can't find the file it's pointed at - the report shows the attachment's bare filename instead of the
+    screenshot.
 - **xUnit:** `Allure.Xunit` requires selecting its reporter (`-- xUnit.ReporterSwitch=allure` or a
   `.runsettings`); it did not engage cleanly under the current VSTest v3 runner, so the xUnit suites are run
   normally and are not in the Allure dashboard yet.

--- a/scripts/run-tests-allure.ps1
+++ b/scripts/run-tests-allure.ps1
@@ -66,8 +66,19 @@ if ($IncludeBlazorUi) {
   # docs/TESTING.md's Allure dashboard section), so it's copied straight into $results as-is rather than
   # converted to the NUnit suites' per-test JSON format.
   dotnet test $playwrightProject --no-build -c Debug --filter "FullyQualifiedName!~ScreenshotCaptureTests" --results-directory $playwrightTrxDir --logger "trx;LogFileName=blazor-ui-tests.trx"
-  Get-ChildItem -Recurse -Path $playwrightTrxDir -Filter 'blazor-ui-tests.trx' -ErrorAction SilentlyContinue |
-    Copy-Item -Destination $results -Force
+
+  # Copy the trx AND every screenshot it references, preserving their relative layout on disk (both
+  # land under $playwrightTrxDir as siblings/descendants from the same test run) instead of copying just
+  # the trx. trx-plugin's <ResultFile> attachment entries point at each PNG using a path relative to the
+  # trx's own location - copy only the trx and that reference resolves to nothing, so the report shows
+  # the attachment's bare filename instead of the actual screenshot inline.
+  Get-ChildItem -Recurse -Path $playwrightTrxDir -Include 'blazor-ui-tests.trx', '*.png' -ErrorAction SilentlyContinue |
+    ForEach-Object {
+      $relative = $_.FullName.Substring($playwrightTrxDir.Length).TrimStart('\', '/')
+      $destination = Join-Path $results $relative
+      New-Item -ItemType Directory -Force -Path (Split-Path $destination -Parent) | Out-Null
+      Copy-Item $_.FullName -Destination $destination -Force
+    }
 }
 
 $count = (Get-ChildItem $results -File -ErrorAction SilentlyContinue | Measure-Object).Count


### PR DESCRIPTION
## Summary
- Fix Allure Playwright screenshots showing up as bare attachment filenames instead of inline images: the `.trx` and its PNGs were uploaded/copied as separately-flattened artifacts, landing at different relative depths so `trx-plugin` couldn't resolve the attachment path. Both the CI workflow (`run-tests.yml`) and the local script (`run-tests-allure.ps1`) now upload/copy the whole result tree as one unit, preserving the relative layout `trx-plugin` needs.
- Cut a Blazor Web (`web-vX.Y.Z`) and API (`api-vX.Y.Z`) zip release on every PR merged into `devmain`, matching how WPF/Android releases already work unconditionally. Removed the `paths:` filters from `deploy-web-smarterasp.yml` / `deploy-api-smarterasp.yml`, which also means every PR into `devmain` now live-deploys Web/API to the production SmarterASP.NET site (not just PRs touching that project's code).

## Test plan
- [ ] Confirm the next CI run on this PR shows the Blazor UI screenshots rendering inline on the Allure dashboard
- [ ] Confirm merging cuts `web-vX.Y.Z` and `api-vX.Y.Z` releases with zip assets attached
- [ ] Watch the SmarterASP.NET deploy steps succeed (or fail gracefully via `continue-on-error`) since they now run unconditionally


---
_Generated by [Claude Code](https://claude.ai/code/session_01PLPFypEk4xaCgcYpf4mWZ4)_